### PR TITLE
feat: Add sealed credentials for agent-provided encrypted headers

### DIFF
--- a/cmd/wardgate/main.go
+++ b/cmd/wardgate/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/wardgate/wardgate/internal/notify"
 	"github.com/wardgate/wardgate/internal/policy"
 	"github.com/wardgate/wardgate/internal/proxy"
+	"github.com/wardgate/wardgate/internal/seal"
 	"github.com/wardgate/wardgate/internal/smtp"
 	sshpkg "github.com/wardgate/wardgate/internal/ssh"
 )
@@ -54,6 +55,7 @@ Commands:
   agent       Manage agents (list, add, remove)
   conclave    Manage conclaves (list, add, remove)
   grants      Manage dynamic grants (list, add, revoke)
+  seal        Encrypt a value using the seal key (uses --key-env or config)
 
 Run 'wardgate <command>' with no args for command-specific help.
 `, version)
@@ -78,6 +80,9 @@ func main() {
 			return
 		case "grants":
 			runGrantsCmd(os.Args[2:])
+			return
+		case "seal":
+			runSealCmd(os.Args[2:])
 			return
 		default:
 			if !strings.HasPrefix(arg, "-") {
@@ -116,6 +121,17 @@ func main() {
 
 	if err := cfg.ValidateEnv(); err != nil {
 		log.Fatalf("Config environment check failed: %v", err)
+	}
+
+	// Initialize sealer if configured
+	var sealer *seal.Sealer
+	if cfg.Server.Seal != nil {
+		var sealErr error
+		sealer, sealErr = seal.New(os.Getenv(cfg.Server.Seal.KeyEnv), cfg.Server.Seal.CacheSize)
+		if sealErr != nil {
+			log.Fatalf("Failed to initialize sealer: %v", sealErr)
+		}
+		log.Printf("Sealed credentials enabled (cache size: %d)", sealer.CacheSize())
 	}
 
 	// Setup components
@@ -267,6 +283,14 @@ func main() {
 				p.SetApprovalManager(approvalMgr)
 			}
 			p.SetGrantStore(grantStore)
+			if sealer != nil {
+				p.SetSealer(sealer)
+				allowedHeaders := cfg.Server.Seal.AllowedHeaders
+				if len(allowedHeaders) == 0 {
+					allowedHeaders = proxy.DefaultAllowedSealHeaders
+				}
+				p.SetAllowedSealHeaders(allowedHeaders)
+			}
 			h = auditMiddleware(auditLog, name, p)
 			log.Printf("Registered HTTP endpoint: /%s/ -> %s", name, endpoint.Upstream)
 		}
@@ -894,4 +918,63 @@ func runGrantsCmd(args []string) {
 		fmt.Fprintf(os.Stderr, "Unknown grants subcommand: %s\n", args[0])
 		os.Exit(1)
 	}
+}
+
+func runSealCmd(args []string) {
+	fs := flag.NewFlagSet("seal", flag.ExitOnError)
+	keyEnvFlag := fs.String("key-env", "", "Environment variable holding the seal key")
+	configPath := fs.String("config", "config.yaml", "Path to config file")
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: wardgate seal [flags] <plaintext-value>\n\n")
+		fmt.Fprintf(os.Stderr, "Encrypts a value using the seal key.\n\n")
+		fmt.Fprintf(os.Stderr, "The key is resolved in order:\n")
+		fmt.Fprintf(os.Stderr, "  1. --key-env flag (env var name)\n")
+		fmt.Fprintf(os.Stderr, "  2. server.seal.key_env from config file\n\n")
+		fmt.Fprintf(os.Stderr, "Flags:\n")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		os.Exit(1)
+	}
+
+	if fs.NArg() == 0 {
+		fs.Usage()
+		os.Exit(1)
+	}
+
+	_ = godotenv.Load(".env") // best effort
+
+	// Resolve key env var name: flag > config > error
+	keyEnv := *keyEnvFlag
+	if keyEnv == "" {
+		if cfg, err := config.LoadFromFile(*configPath); err == nil && cfg.Server.Seal != nil {
+			keyEnv = cfg.Server.Seal.KeyEnv
+		}
+	}
+	if keyEnv == "" {
+		fmt.Fprintln(os.Stderr, "Error: seal key env not configured")
+		fmt.Fprintln(os.Stderr, "Provide --key-env flag or set server.seal.key_env in config.yaml")
+		os.Exit(1)
+	}
+
+	hexKey := os.Getenv(keyEnv)
+	if hexKey == "" {
+		fmt.Fprintf(os.Stderr, "Error: environment variable %s is not set\n", keyEnv)
+		os.Exit(1)
+	}
+
+	s, err := seal.New(hexKey, 1) // cache size irrelevant for one-shot
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating sealer: %v\n", err)
+		os.Exit(1)
+	}
+
+	sealed, err := s.Encrypt(fs.Arg(0))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error encrypting: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println(sealed)
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -266,6 +266,8 @@ Server configuration.
 | `admin_key_env` | string | | Env var for admin key (enables Web UI at `/ui/` and CLI) |
 | `logging.max_entries` | int | `1000` | Max log entries to keep in memory for dashboard |
 | `logging.store_bodies` | bool | `false` | Store request bodies in logs (privacy consideration) |
+| `seal.key_env` | string | | Env var holding 32-byte hex AES-256 key for [sealed credentials](sealed-credentials.md) |
+| `seal.cache_size` | int | `1000` | Max entries in the decryption LRU cache |
 
 ```yaml
 server:
@@ -426,18 +428,28 @@ Authentication configuration for the upstream service.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `type` | string | Yes | Authentication type (`bearer`) |
-| `credential_env` | string | Yes | Environment variable containing the credential |
+| `type` | string | Yes* | Authentication type (`bearer`) |
+| `credential_env` | string | Yes* | Environment variable containing the credential |
+| `sealed` | bool | No | Credentials come from agent's encrypted `X-Wardgate-Sealed-*` headers |
+
+\* Not required when `sealed: true`.
 
 ```yaml
+# Static credentials (Wardgate injects from vault)
 auth:
   type: bearer
   credential_env: WARDGATE_CRED_TODOIST_API_KEY
+
+# Sealed credentials (agent provides encrypted values)
+auth:
+  sealed: true
 ```
 
 Currently supported types:
 - `bearer` - Adds `Authorization: Bearer <credential>` header
 - `plain` - For IMAP: credential format is `username:password`
+
+When `sealed: true`, the agent sends encrypted header values prefixed with `X-Wardgate-Sealed-*`. Wardgate decrypts and forwards them. See **[Sealed Credentials](sealed-credentials.md)** for full documentation.
 
 ### endpoints.rules
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,7 @@ conclaves:
 ### API Gateway
 
 - [Presets Reference](presets.md) -- Built-in presets, capabilities, and how to create your own
+- [Sealed Credentials](sealed-credentials.md) -- Let agents carry their own encrypted API keys
 - [Configuration Reference](config.md) -- All configuration options including sensitive data filtering
 
 ### Conclaves

--- a/docs/sealed-credentials.md
+++ b/docs/sealed-credentials.md
@@ -1,0 +1,219 @@
+# Sealed Credentials
+
+Sealed credentials let agents carry their own encrypted API keys. Wardgate decrypts them at proxy time and forwards the real values to upstream services. Agents never see the plaintext -- even if they dump the encrypted values, those are useless without the seal key (which lives only on the Wardgate server).
+
+## When to Use
+
+**Static credentials** (`credential_env`) work well when the operator controls all upstream API keys centrally. Sealed credentials are better when:
+
+- Agents need **individual API keys** for the same service (e.g., per-agent GitHub tokens)
+- You're running agents in **sandboxed environments** (conclaves) and don't want to manage every upstream key on the server
+- You want the agent to **control which headers** reach upstream (any auth scheme: Bearer, API key, Basic, custom headers)
+
+## How It Works
+
+The operator encrypts upstream credentials using a shared seal key. The encrypted values are given to agents (e.g., as environment variables in their sandbox). Agents send them as `X-Wardgate-Sealed-*` prefixed headers. Wardgate strips the prefix, decrypts, and forwards.
+
+```
+Agent sends:
+  Authorization: Bearer <jwt-for-wardgate-auth>
+  X-Wardgate-Sealed-Authorization: <encrypt("Bearer ghp_realtoken")>
+  X-Wardgate-Sealed-X-Api-Key:     <encrypt("key_12345")>
+
+Wardgate processes:
+  1. JWT auth validates agent identity
+  2. Strip "X-Wardgate-Sealed-" prefix  ->  Authorization, X-Api-Key
+  3. Decrypt value                      ->  "Bearer ghp_realtoken", "key_12345"
+  4. Strip agent's Authorization header (it's for Wardgate, not upstream)
+
+Upstream receives:
+  Authorization: Bearer ghp_realtoken
+  X-Api-Key: key_12345
+```
+
+No mapping config needed. The agent is in full control of what headers reach upstream.
+
+## Setup
+
+### 1. Generate a seal key
+
+```bash
+# Generate a 32-byte hex-encoded AES-256 key
+export WARDGATE_SEAL_KEY=$(openssl rand -hex 32)
+
+# Add to your .env file
+echo "WARDGATE_SEAL_KEY=$WARDGATE_SEAL_KEY" >> .env
+```
+
+### 2. Configure the server
+
+```yaml
+server:
+  listen: :8080
+  jwt:
+    secret_env: JWT_SECRET
+  seal:
+    key_env: WARDGATE_SEAL_KEY    # 32-byte hex-encoded AES-256 key
+
+endpoints:
+  github:
+    upstream: https://api.github.com
+    auth:
+      sealed: true                # credentials come from agent's sealed headers
+    rules:
+      - match: { method: GET }
+        action: allow
+      - match: { method: POST, path: "/repos/*/issues" }
+        action: allow
+      - match: { method: "*" }
+        action: deny
+```
+
+When `sealed: true`:
+- `type` and `credential_env` are **not required** (the agent provides credentials)
+- `credential_env` and `sealed` are **mutually exclusive** -- you cannot set both
+- `server.seal` must be configured or validation fails
+- All policy evaluation (rules, grants, rate limits) still applies normally
+
+### Header Whitelist (Optional)
+
+By default, only common authentication headers are allowed to be sealed:
+- `Authorization`
+- `X-Api-Key`
+- `X-Auth-Token`
+- `Proxy-Authorization`
+
+To allow additional headers, configure `allowed_headers`:
+
+```yaml
+server:
+  seal:
+    key_env: WARDGATE_SEAL_KEY
+    allowed_headers:
+      - Authorization
+      - X-Api-Key
+      - X-Custom-Header  # Allow custom headers if needed
+```
+
+Headers not in the whitelist will be rejected to prevent agents from sealing sensitive headers like `Host` or `Cookie`.
+
+### 3. Encrypt credentials for agents
+
+```bash
+# Encrypt an upstream API token
+wardgate seal "Bearer ghp_agent1_github_token"
+# Output: c2VhbGVkX1...base64...
+
+# Encrypt an API key
+wardgate seal "key_12345"
+# Output: YWJjZGVm...base64...
+```
+
+The `seal` command reads `WARDGATE_SEAL_KEY` from the environment (or `.env` file).
+
+### 4. Give encrypted values to agents
+
+Inject the encrypted values as environment variables in the agent's sandbox:
+
+```bash
+# Agent's environment
+GITHUB_SEALED="c2VhbGVkX1...base64..."
+```
+
+### 5. Agent makes requests
+
+The agent prefixes each upstream header name with `X-Wardgate-Sealed-`:
+
+```bash
+wardgate-cli \
+  -H "X-Wardgate-Sealed-Authorization: $GITHUB_SEALED" \
+  https://api.github.com/repos/owner/repo/issues
+```
+
+## Configuration Reference
+
+### server.seal
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `key_env` | string | (required) | Environment variable holding the 32-byte hex-encoded AES-256 key |
+| `cache_size` | int | `1000` | Maximum number of entries in the decryption LRU cache |
+| `allowed_headers` | []string | `["Authorization", "X-Api-Key", "X-Auth-Token", "Proxy-Authorization"]` | Whitelist of header names that can be sealed. If empty, defaults to common auth headers. |
+
+### endpoints.auth.sealed
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `sealed` | bool | `false` | When `true`, credentials come from agent's `X-Wardgate-Sealed-*` headers |
+
+## Encryption Details
+
+- **Algorithm**: AES-256-GCM (authenticated encryption from Go standard library)
+- **Key**: 32 bytes, stored as hex in an environment variable
+- **Sealed format**: `base64(12-byte-nonce || ciphertext || GCM-tag)`
+- **No new dependencies**: uses `crypto/aes` and `crypto/cipher` from the Go standard library
+
+Each encryption produces a unique ciphertext (random nonce), so encrypting the same value twice yields different outputs. Decryption is deterministic.
+
+## Decryption Cache
+
+To avoid repeated AES-GCM decryption for the same sealed values across requests, Wardgate caches results in a fixed-size LRU (least recently used) cache.
+
+- **Key**: the sealed ciphertext string (same ciphertext always maps to the same plaintext)
+- **Eviction**: when the cache is full, the least recently used entry is evicted
+- **Capacity**: configurable via `cache_size` (default: 1000 entries)
+- **Thread safety**: mutex-protected for concurrent access
+
+The cache is purely a performance optimization. Evicted entries are re-decrypted on the next request. There is no TTL -- the ciphertext-to-plaintext mapping is deterministic, so cached entries never become stale.
+
+## Mixing Static and Sealed Endpoints
+
+Sealed credentials are configured per-endpoint. Existing static credential endpoints continue to work unchanged:
+
+```yaml
+endpoints:
+  # Sealed: agent provides encrypted credentials
+  github:
+    upstream: https://api.github.com
+    auth:
+      sealed: true
+    rules: [...]
+
+  # Static: Wardgate injects credential from vault
+  todoist:
+    upstream: https://api.todoist.com
+    auth:
+      type: bearer
+      credential_env: TODOIST_TOKEN
+    rules: [...]
+```
+
+## Multiple Sealed Headers
+
+The agent can send multiple `X-Wardgate-Sealed-*` headers in a single request. Each is independently decrypted and forwarded:
+
+```bash
+wardgate-cli \
+  -H "X-Wardgate-Sealed-Authorization: $AUTH_SEALED" \
+  -H "X-Wardgate-Sealed-X-Api-Key: $KEY_SEALED" \
+  -H "X-Wardgate-Sealed-X-Custom-Header: $CUSTOM_SEALED" \
+  https://api.example.com/data
+```
+
+## Error Handling
+
+| Condition | Response |
+|-----------|----------|
+| No `X-Wardgate-Sealed-*` headers on a sealed endpoint | `400 Bad Request` |
+| Invalid base64 encoding | Header is skipped (logged) |
+| Tampered or invalid ciphertext | Header is skipped (logged) |
+| Wrong seal key | Decryption fails, header is skipped |
+
+## Security Considerations
+
+- The seal key must be kept secret. It should only exist on the Wardgate server (in the `.env` file or process environment).
+- Encrypted values are safe to give to agents -- they cannot be decrypted without the seal key.
+- All policy rules, rate limits, grants, and approval workflows still apply to sealed endpoints.
+- Sealed headers are stripped before forwarding to upstream -- the upstream never sees `X-Wardgate-Sealed-*` headers.
+- Non-sealed headers (e.g., `Content-Type`, `Accept`) are passed through to upstream unchanged.
+- Sealed values have no replay protection -- the same encrypted value can be used across multiple requests. This is by design, as sealed credentials represent long-lived API keys that agents reuse. Treat sealed values with the same care as the plaintext credentials they contain.

--- a/e2e/sealed_test.go
+++ b/e2e/sealed_test.go
@@ -1,0 +1,366 @@
+package e2e
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/wardgate/wardgate/internal/auth"
+	"github.com/wardgate/wardgate/internal/config"
+	"github.com/wardgate/wardgate/internal/policy"
+	"github.com/wardgate/wardgate/internal/proxy"
+	"github.com/wardgate/wardgate/internal/seal"
+)
+
+// TestSealedCredentials_E2E exercises the full sealed credentials flow:
+//
+//	agent → auth middleware → policy engine → proxy (sealed header decryption) → upstream
+//
+// This tests the same code path as a real Wardgate deployment, wired together
+// the same way main.go does it, but using httptest servers.
+func TestSealedCredentials_E2E(t *testing.T) {
+	// --- 1. Generate keys ---
+	sealKey := randomHexKey(t, 32)
+	agentKey := "test-agent-key-" + randomHexKey(t, 8)
+
+	// --- 2. Create sealer ---
+	sealer, err := seal.New(sealKey, 100)
+	if err != nil {
+		t.Fatalf("seal.New: %v", err)
+	}
+
+	// --- 3. Encrypt upstream credentials ---
+	sealedAuth, err := sealer.Encrypt("Bearer ghp_realtoken123")
+	if err != nil {
+		t.Fatalf("Encrypt auth: %v", err)
+	}
+	sealedAPIKey, err := sealer.Encrypt("sk-secret-api-key")
+	if err != nil {
+		t.Fatalf("Encrypt API key: %v", err)
+	}
+
+	// --- 4. Start mock upstream server ---
+	type upstreamRequest struct {
+		method  string
+		path    string
+		headers http.Header
+		body    string
+	}
+	var lastUpstreamReq upstreamRequest
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		lastUpstreamReq = upstreamRequest{
+			method:  r.Method,
+			path:    r.URL.Path,
+			headers: r.Header.Clone(),
+			body:    string(body),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Upstream-Response", "true")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"result": "success", "items": [1, 2, 3]}`))
+	}))
+	defer upstream.Close()
+
+	// --- 5. Build Wardgate config ---
+	agentKeyEnv := "TEST_E2E_AGENT_KEY"
+	t.Setenv(agentKeyEnv, agentKey)
+
+	agents := []config.AgentConfig{
+		{ID: "test-agent", KeyEnv: agentKeyEnv},
+	}
+
+	endpoint := config.Endpoint{
+		Upstream: upstream.URL,
+		Auth:     config.AuthConfig{Sealed: true},
+	}
+
+	rules := []config.Rule{
+		{Match: config.Match{Method: "GET"}, Action: "allow"},
+		{Match: config.Match{Method: "POST", Path: "/resources"}, Action: "allow"},
+		{Match: config.Match{Method: "DELETE"}, Action: "deny", Message: "deletion not allowed"},
+		{Match: config.Match{Method: "*"}, Action: "deny", Message: "not permitted"},
+	}
+	engine := policy.New(rules)
+
+	// --- 6. Wire up components (mirrors main.go) ---
+	vault := &mockVault{creds: map[string]string{}}
+	p := proxy.NewWithName("sealed-api", endpoint, vault, engine)
+	p.SetSealer(sealer)
+	p.SetAllowedSealHeaders([]string{
+		"Authorization",
+		"X-Api-Key",
+		"X-Bad-Header",
+		"X-Custom-Header",
+	})
+
+	apiMux := http.NewServeMux()
+	apiMux.Handle("/sealed-api/", http.StripPrefix("/sealed-api", p))
+
+	// Wrap with agent auth middleware (same as main.go)
+	gateway := auth.NewAgentAuthMiddleware(agents, nil, apiMux)
+
+	// --- 7. Start gateway server ---
+	gw := httptest.NewServer(gateway)
+	defer gw.Close()
+
+	client := gw.Client()
+
+	// ==========================================
+	// Test cases
+	// ==========================================
+
+	t.Run("unauthenticated request returns 401", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", gw.URL+"/sealed-api/data", nil)
+		// No Authorization header
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("wrong agent key returns 401", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", gw.URL+"/sealed-api/data", nil)
+		req.Header.Set("Authorization", "Bearer wrong-key")
+		req.Header.Set("X-Wardgate-Sealed-Authorization", sealedAuth)
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("missing sealed headers returns 400", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", gw.URL+"/sealed-api/data", nil)
+		req.Header.Set("Authorization", "Bearer "+agentKey)
+		// No X-Wardgate-Sealed-* headers
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("policy deny returns 403", func(t *testing.T) {
+		req, _ := http.NewRequest("DELETE", gw.URL+"/sealed-api/resources/123", nil)
+		req.Header.Set("Authorization", "Bearer "+agentKey)
+		req.Header.Set("X-Wardgate-Sealed-Authorization", sealedAuth)
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("expected 403, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("sealed GET: decrypts and forwards single header", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", gw.URL+"/sealed-api/repos/owner/repo", nil)
+		req.Header.Set("Authorization", "Bearer "+agentKey)
+		req.Header.Set("X-Wardgate-Sealed-Authorization", sealedAuth)
+		req.Header.Set("Accept", "application/json")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+		}
+
+		// Verify upstream received decrypted Authorization
+		if got := lastUpstreamReq.headers.Get("Authorization"); got != "Bearer ghp_realtoken123" {
+			t.Errorf("upstream Authorization = %q, want %q", got, "Bearer ghp_realtoken123")
+		}
+
+		// Verify agent's original auth was stripped (not forwarded to upstream)
+		// The decrypted value should be there, not the agent's JWT
+		if got := lastUpstreamReq.headers.Get("Authorization"); strings.Contains(got, agentKey) {
+			t.Error("agent auth key leaked to upstream")
+		}
+
+		// Verify sealed header prefix was stripped
+		if got := lastUpstreamReq.headers.Get("X-Wardgate-Sealed-Authorization"); got != "" {
+			t.Errorf("sealed header prefix leaked to upstream: %q", got)
+		}
+
+		// Verify regular headers passed through
+		if got := lastUpstreamReq.headers.Get("Accept"); got != "application/json" {
+			t.Errorf("Accept header not forwarded: %q", got)
+		}
+
+		// Verify response from upstream forwarded back
+		body, _ := io.ReadAll(resp.Body)
+		if !strings.Contains(string(body), `"result": "success"`) {
+			t.Errorf("unexpected response body: %s", body)
+		}
+		if resp.Header.Get("X-Upstream-Response") != "true" {
+			t.Error("upstream response headers not forwarded")
+		}
+	})
+
+	t.Run("sealed POST: decrypts multiple headers and forwards body", func(t *testing.T) {
+		reqBody := `{"name": "test-resource"}`
+		req, _ := http.NewRequest("POST", gw.URL+"/sealed-api/resources", strings.NewReader(reqBody))
+		req.Header.Set("Authorization", "Bearer "+agentKey)
+		req.Header.Set("X-Wardgate-Sealed-Authorization", sealedAuth)
+		req.Header.Set("X-Wardgate-Sealed-X-Api-Key", sealedAPIKey)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Request-Id", "req-e2e-001")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+		}
+
+		// Verify both sealed headers decrypted
+		if got := lastUpstreamReq.headers.Get("Authorization"); got != "Bearer ghp_realtoken123" {
+			t.Errorf("upstream Authorization = %q, want decrypted", got)
+		}
+		if got := lastUpstreamReq.headers.Get("X-Api-Key"); got != "sk-secret-api-key" {
+			t.Errorf("upstream X-Api-Key = %q, want decrypted", got)
+		}
+
+		// Verify sealed prefixes stripped
+		if lastUpstreamReq.headers.Get("X-Wardgate-Sealed-Authorization") != "" {
+			t.Error("X-Wardgate-Sealed-Authorization leaked to upstream")
+		}
+		if lastUpstreamReq.headers.Get("X-Wardgate-Sealed-X-Api-Key") != "" {
+			t.Error("X-Wardgate-Sealed-X-Api-Key leaked to upstream")
+		}
+
+		// Verify regular headers and body passed through
+		if got := lastUpstreamReq.headers.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type not forwarded: %q", got)
+		}
+		if got := lastUpstreamReq.headers.Get("X-Request-Id"); got != "req-e2e-001" {
+			t.Errorf("X-Request-Id not forwarded: %q", got)
+		}
+		if lastUpstreamReq.body != reqBody {
+			t.Errorf("request body not forwarded: %q", lastUpstreamReq.body)
+		}
+		if lastUpstreamReq.method != "POST" {
+			t.Errorf("method not forwarded: %s", lastUpstreamReq.method)
+		}
+		if lastUpstreamReq.path != "/resources" {
+			t.Errorf("path not forwarded: %s", lastUpstreamReq.path)
+		}
+	})
+
+	t.Run("invalid sealed value: valid headers still forwarded", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", gw.URL+"/sealed-api/data", nil)
+		req.Header.Set("Authorization", "Bearer "+agentKey)
+		req.Header.Set("X-Wardgate-Sealed-Authorization", sealedAuth)
+		req.Header.Set("X-Wardgate-Sealed-X-Bad-Header", "invalid-not-base64!!!")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+
+		// Valid sealed header should still be decrypted
+		if got := lastUpstreamReq.headers.Get("Authorization"); got != "Bearer ghp_realtoken123" {
+			t.Errorf("valid sealed header should still be forwarded: %q", got)
+		}
+		// Invalid header should be skipped
+		if got := lastUpstreamReq.headers.Get("X-Bad-Header"); got != "" {
+			t.Errorf("invalid sealed header should be skipped, got: %q", got)
+		}
+	})
+
+	t.Run("policy denied method with sealed headers returns 403", func(t *testing.T) {
+		req, _ := http.NewRequest("PUT", gw.URL+"/sealed-api/resources/123", nil)
+		req.Header.Set("Authorization", "Bearer "+agentKey)
+		req.Header.Set("X-Wardgate-Sealed-Authorization", sealedAuth)
+
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("expected 403 for PUT (not permitted), got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("sealed endpoint with custom non-auth header", func(t *testing.T) {
+		sealedCustom, err := sealer.Encrypt("custom-value-123")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		req, _ := http.NewRequest("GET", gw.URL+"/sealed-api/data", nil)
+		req.Header.Set("Authorization", "Bearer "+agentKey)
+		req.Header.Set("X-Wardgate-Sealed-X-Custom-Header", sealedCustom)
+
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+
+		if got := lastUpstreamReq.headers.Get("X-Custom-Header"); got != "custom-value-123" {
+			t.Errorf("custom sealed header = %q, want %q", got, "custom-value-123")
+		}
+		// Agent auth should have been stripped
+		if got := lastUpstreamReq.headers.Get("Authorization"); strings.Contains(got, agentKey) {
+			t.Error("agent auth key leaked to upstream with custom sealed header")
+		}
+	})
+}
+
+// mockVault implements auth.Vault for testing.
+type mockVault struct {
+	creds map[string]string
+}
+
+func (m *mockVault) Get(name string) (string, error) {
+	if cred, ok := m.creds[name]; ok {
+		return cred, nil
+	}
+	return "", auth.ErrCredentialNotFound
+}
+
+func randomHexKey(t *testing.T, bytes int) string {
+	t.Helper()
+	key := make([]byte, bytes)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatal(err)
+	}
+	return hex.EncodeToString(key)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -248,6 +248,13 @@ type JWTConfig struct {
 	Audience  string `yaml:"audience,omitempty"`   // Expected "aud" claim (optional)
 }
 
+// SealConfig defines sealed credential decryption settings.
+type SealConfig struct {
+	KeyEnv         string   `yaml:"key_env"`
+	CacheSize      int      `yaml:"cache_size,omitempty"`       // LRU cache capacity (default: 1000)
+	AllowedHeaders []string `yaml:"allowed_headers,omitempty"`  // Whitelist of headers that can be sealed
+}
+
 // ServerConfig holds server settings.
 type ServerConfig struct {
 	Listen      string        `yaml:"listen"`
@@ -256,6 +263,7 @@ type ServerConfig struct {
 	GrantsFile  string        `yaml:"grants_file,omitempty"`   // Path to grants file (default: grants.json)
 	Logging     LoggingConfig `yaml:"logging,omitempty"`       // Logging dashboard configuration
 	JWT         *JWTConfig    `yaml:"jwt,omitempty"`           // JWT agent authentication (optional)
+	Seal        *SealConfig   `yaml:"seal,omitempty"`          // Sealed credential decryption (optional)
 }
 
 // LoggingConfig holds logging dashboard settings.
@@ -357,6 +365,7 @@ type SMTPConfig struct {
 type AuthConfig struct {
 	Type          string `yaml:"type"`
 	CredentialEnv string `yaml:"credential_env"`
+	Sealed        bool   `yaml:"sealed,omitempty"` // Credentials come from agent's sealed headers
 }
 
 // Rule defines a policy rule for an endpoint.
@@ -608,6 +617,13 @@ func (c *Config) validate() error {
 		}
 	}
 
+	// Validate seal config
+	if c.Server.Seal != nil {
+		if c.Server.Seal.KeyEnv == "" {
+			return fmt.Errorf("server.seal: missing key_env")
+		}
+	}
+
 	for name, ep := range c.Endpoints {
 		if len(ep.Capabilities) > 0 && ep.Preset == "" {
 			return fmt.Errorf("endpoint %q: capabilities require a preset", name)
@@ -654,7 +670,14 @@ func (c *Config) validate() error {
 		if ep.Upstream == "" {
 			return fmt.Errorf("endpoint %q: missing upstream", name)
 		}
-		if ep.Auth.Type == "" || ep.Auth.CredentialEnv == "" {
+		if ep.Auth.Sealed {
+			if ep.Auth.CredentialEnv != "" {
+				return fmt.Errorf("endpoint %q: sealed and credential_env are mutually exclusive", name)
+			}
+			if c.Server.Seal == nil {
+				return fmt.Errorf("endpoint %q: sealed requires server.seal configuration", name)
+			}
+		} else if ep.Auth.Type == "" || ep.Auth.CredentialEnv == "" {
 			return fmt.Errorf("endpoint %q: missing auth configuration", name)
 		}
 		for i, rule := range ep.Rules {
@@ -706,6 +729,16 @@ func (c *Config) ValidateEnv() error {
 		}
 		if val == "" {
 			log.Printf("Warning: server: environment variable %s is set but empty", c.Server.AdminKeyEnv)
+		}
+	}
+
+	if c.Server.Seal != nil && c.Server.Seal.KeyEnv != "" {
+		val, ok := os.LookupEnv(c.Server.Seal.KeyEnv)
+		if !ok {
+			return fmt.Errorf("server.seal: environment variable %s not set (referenced by key_env)", c.Server.Seal.KeyEnv)
+		}
+		if val == "" {
+			log.Printf("Warning: server.seal: environment variable %s is set but empty", c.Server.Seal.KeyEnv)
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1421,6 +1421,194 @@ endpoints:
 	}
 }
 
+// Sealed credential tests
+
+func TestLoadConfig_SealedEndpointValid(t *testing.T) {
+	yaml := `
+server:
+  listen: ":8080"
+  seal:
+    key_env: WARDGATE_SEAL_KEY
+endpoints:
+  github:
+    upstream: https://api.github.com
+    auth:
+      sealed: true
+    rules:
+      - match: { method: GET }
+        action: allow
+`
+	cfg, err := LoadFromReader(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ep := cfg.Endpoints["github"]
+	if !ep.Auth.Sealed {
+		t.Error("expected sealed to be true")
+	}
+	if ep.Auth.Type != "" {
+		t.Errorf("expected empty auth type for sealed, got %s", ep.Auth.Type)
+	}
+}
+
+func TestLoadConfig_SealedWithoutServerSeal(t *testing.T) {
+	yaml := `
+server:
+  listen: ":8080"
+endpoints:
+  github:
+    upstream: https://api.github.com
+    auth:
+      sealed: true
+`
+	_, err := LoadFromReader(strings.NewReader(yaml))
+	if err == nil {
+		t.Fatal("expected error when sealed without server.seal")
+	}
+	if !strings.Contains(err.Error(), "sealed requires server.seal") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_SealedWithCredentialEnv(t *testing.T) {
+	yaml := `
+server:
+  listen: ":8080"
+  seal:
+    key_env: WARDGATE_SEAL_KEY
+endpoints:
+  github:
+    upstream: https://api.github.com
+    auth:
+      sealed: true
+      credential_env: GITHUB_TOKEN
+`
+	_, err := LoadFromReader(strings.NewReader(yaml))
+	if err == nil {
+		t.Fatal("expected error when sealed and credential_env both set")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_SealMissingKeyEnv(t *testing.T) {
+	yaml := `
+server:
+  listen: ":8080"
+  seal:
+    cache_size: 500
+endpoints:
+  test:
+    upstream: https://example.com
+    auth:
+      type: bearer
+      credential_env: TEST_KEY
+`
+	_, err := LoadFromReader(strings.NewReader(yaml))
+	if err == nil {
+		t.Fatal("expected error for seal missing key_env")
+	}
+	if !strings.Contains(err.Error(), "key_env") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_SealedEndpointWithCacheSize(t *testing.T) {
+	yaml := `
+server:
+  listen: ":8080"
+  seal:
+    key_env: WARDGATE_SEAL_KEY
+    cache_size: 500
+endpoints:
+  github:
+    upstream: https://api.github.com
+    auth:
+      sealed: true
+    rules:
+      - match: { method: GET }
+        action: allow
+`
+	cfg, err := LoadFromReader(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Server.Seal.CacheSize != 500 {
+		t.Errorf("expected cache_size 500, got %d", cfg.Server.Seal.CacheSize)
+	}
+}
+
+func TestValidateEnv_SealKeyEnvMissing(t *testing.T) {
+	os.Unsetenv("WARDGATE_NONEXISTENT_SEAL_KEY")
+	cfg := &Config{
+		Server: ServerConfig{
+			Seal: &SealConfig{KeyEnv: "WARDGATE_NONEXISTENT_SEAL_KEY"},
+		},
+	}
+	err := cfg.ValidateEnv()
+	if err == nil {
+		t.Fatal("expected error for missing seal key_env")
+	}
+	if !strings.Contains(err.Error(), "WARDGATE_NONEXISTENT_SEAL_KEY") {
+		t.Errorf("error should mention env var name: %v", err)
+	}
+}
+
+func TestValidateEnv_SealKeyEnvPresent(t *testing.T) {
+	t.Setenv("TEST_SEAL_KEY", "abcd1234")
+	cfg := &Config{
+		Server: ServerConfig{
+			Seal: &SealConfig{KeyEnv: "TEST_SEAL_KEY"},
+		},
+	}
+	if err := cfg.ValidateEnv(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_SealedWithAllowedHeaders(t *testing.T) {
+	yaml := `
+server:
+  seal:
+    key_env: TEST_SEAL_KEY
+    allowed_headers:
+      - Authorization
+      - X-Custom-Auth
+
+endpoints:
+  github:
+    upstream: https://api.github.com
+    auth:
+      sealed: true
+    rules:
+      - match: { method: GET }
+        action: allow
+`
+	cfg, err := LoadFromReader(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Server.Seal == nil {
+		t.Fatal("expected seal config")
+	}
+
+	if len(cfg.Server.Seal.AllowedHeaders) != 2 {
+		t.Errorf("expected 2 allowed headers, got %d", len(cfg.Server.Seal.AllowedHeaders))
+	}
+
+	if cfg.Server.Seal.AllowedHeaders[0] != "Authorization" {
+		t.Errorf("expected first header Authorization, got %s", cfg.Server.Seal.AllowedHeaders[0])
+	}
+
+	if cfg.Server.Seal.AllowedHeaders[1] != "X-Custom-Auth" {
+		t.Errorf("expected second header X-Custom-Auth, got %s", cfg.Server.Seal.AllowedHeaders[1])
+	}
+}
+
 func TestLoadConfig_CapabilitiesWithoutPreset(t *testing.T) {
 	yaml := `
 endpoints:

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -17,24 +18,68 @@ import (
 	"github.com/wardgate/wardgate/internal/filter"
 	"github.com/wardgate/wardgate/internal/grants"
 	"github.com/wardgate/wardgate/internal/policy"
+	"github.com/wardgate/wardgate/internal/seal"
 )
+
+const sealedHeaderPrefix = "X-Wardgate-Sealed-"
+
+// DefaultAllowedSealHeaders is the default whitelist of headers that can be sealed.
+// Only common auth-related headers are allowed unless the operator expands the list.
+var DefaultAllowedSealHeaders = []string{
+	"Authorization",
+	"X-Api-Key",
+	"X-Auth-Token",
+	"Proxy-Authorization",
+}
 
 // Proxy handles HTTP requests to an endpoint.
 type Proxy struct {
-	endpoint     config.Endpoint
-	endpointName string
-	vault        auth.Vault
-	engine       *policy.Engine
-	upstream     *url.URL
-	timeout      time.Duration
-	approvals    *approval.Manager
-	filter       *filter.Filter
-	grantStore   *grants.Store
+	endpoint           config.Endpoint
+	endpointName       string
+	vault              auth.Vault
+	engine             *policy.Engine
+	upstream           *url.URL
+	timeout            time.Duration
+	approvals          *approval.Manager
+	filter             *filter.Filter
+	grantStore         *grants.Store
+	sealer             *seal.Sealer
+	allowedSealHeaders map[string]bool
+}
+
+// SetSealer sets the sealer for decrypting sealed credential headers.
+func (p *Proxy) SetSealer(s *seal.Sealer) {
+	p.sealer = s
+}
+
+// SetAllowedSealHeaders sets the whitelist of headers that can be sealed.
+// If headers is empty, uses the default allowed headers.
+// Headers are normalized using http.CanonicalHeaderKey for case-insensitive comparison.
+func (p *Proxy) SetAllowedSealHeaders(headers []string) {
+	if len(headers) == 0 {
+		headers = DefaultAllowedSealHeaders
+	}
+	p.allowedSealHeaders = make(map[string]bool, len(headers))
+	for _, h := range headers {
+		p.allowedSealHeaders[http.CanonicalHeaderKey(h)] = true
+	}
+}
+
+func (p *Proxy) isSealHeaderAllowed(header string) bool {
+	if p.allowedSealHeaders == nil {
+		return false
+	}
+	return p.allowedSealHeaders[http.CanonicalHeaderKey(header)]
 }
 
 // SetGrantStore sets the grant store for dynamic policy overrides.
 func (p *Proxy) SetGrantStore(s *grants.Store) {
 	p.grantStore = s
+}
+
+// SetSSEMode is a placeholder for SSE mode configuration.
+func (p *Proxy) SetSSEMode(mode string) {
+	// TODO: Implement SSE mode support
 }
 
 // New creates a new proxy for the given endpoint.
@@ -118,11 +163,27 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Get credential
-	cred, err := p.vault.Get(p.endpoint.Auth.CredentialEnv)
-	if err != nil {
-		http.Error(w, "credential error", http.StatusInternalServerError)
-		return
+	// Get credential (skip for sealed — agent provides credentials)
+	var cred string
+	if p.endpoint.Auth.Sealed {
+		hasSealedHeader := false
+		for name := range r.Header {
+			if strings.HasPrefix(name, sealedHeaderPrefix) {
+				hasSealedHeader = true
+				break
+			}
+		}
+		if !hasSealedHeader {
+			http.Error(w, "missing X-Wardgate-Sealed-* headers", http.StatusBadRequest)
+			return
+		}
+	} else {
+		var err error
+		cred, err = p.vault.Get(p.endpoint.Auth.CredentialEnv)
+		if err != nil {
+			http.Error(w, "credential error", http.StatusInternalServerError)
+			return
+		}
 	}
 
 	// Create reverse proxy
@@ -133,8 +194,9 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			req.URL.Path = p.upstream.Path + r.URL.Path
 			req.Host = p.upstream.Host
 
-			// Inject credential (strip agent auth first)
-			if p.endpoint.Auth.Type == "bearer" {
+			if p.endpoint.Auth.Sealed && p.sealer != nil {
+				p.processSealedHeaders(req, r.Header)
+			} else if p.endpoint.Auth.Type == "bearer" {
 				req.Header.Set("Authorization", "Bearer "+cred)
 			}
 		},
@@ -154,6 +216,35 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r = r.WithContext(ctx)
 
 	proxy.ServeHTTP(w, r)
+}
+
+// processSealedHeaders decrypts X-Wardgate-Sealed-* headers and sets the real
+// headers on the outgoing request. Only headers in the allowed whitelist are processed.
+func (p *Proxy) processSealedHeaders(req *http.Request, incoming http.Header) {
+	// Remove agent's Wardgate auth header before setting decrypted values
+	req.Header.Del("Authorization")
+
+	for name, values := range incoming {
+		if !strings.HasPrefix(name, sealedHeaderPrefix) {
+			continue
+		}
+		realHeader := strings.TrimPrefix(name, sealedHeaderPrefix)
+		if !p.isSealHeaderAllowed(realHeader) {
+			log.Printf("sealed header %q not in allowed list, skipping", realHeader)
+			req.Header.Del(name)
+			continue
+		}
+		req.Header.Del(realHeader) // clear before Add loop so only decrypted values remain
+		for _, sealed := range values {
+			plaintext, err := p.sealer.Decrypt(sealed)
+			if err != nil {
+				log.Printf("failed to decrypt sealed header %q: %v", realHeader, err)
+				continue
+			}
+			req.Header.Add(realHeader, plaintext)
+		}
+		req.Header.Del(name)
+	}
 }
 
 // modifyResponse filters sensitive data from response bodies.

--- a/internal/proxy/http_test.go
+++ b/internal/proxy/http_test.go
@@ -1,6 +1,8 @@
 package proxy
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +15,7 @@ import (
 	"github.com/wardgate/wardgate/internal/filter"
 	"github.com/wardgate/wardgate/internal/grants"
 	"github.com/wardgate/wardgate/internal/policy"
+	"github.com/wardgate/wardgate/internal/seal"
 )
 
 // mockVault implements auth.Vault for testing
@@ -429,5 +432,546 @@ func TestProxy_GrantOverridesPolicy(t *testing.T) {
 	}
 	if rec.Code != http.StatusOK {
 		t.Errorf("expected 200, got %d", rec.Code)
+	}
+}
+
+func newTestSealer(t *testing.T) *seal.Sealer {
+	t.Helper()
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatal(err)
+	}
+	s, err := seal.New(hex.EncodeToString(key), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func TestProxy_SealedHeaderForwarded(t *testing.T) {
+	var receivedAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	sealer := newTestSealer(t)
+	sealedValue, err := sealer.Encrypt("Bearer ghp_realtoken")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vault := &mockVault{creds: map[string]string{}}
+	endpoint := config.Endpoint{
+		Upstream: upstream.URL,
+		Auth:     config.AuthConfig{Sealed: true},
+	}
+	engine := policy.New([]config.Rule{{Match: config.Match{Method: "*"}, Action: "allow"}})
+
+	p := New(endpoint, vault, engine)
+	p.SetSealer(sealer)
+	p.SetAllowedSealHeaders(DefaultAllowedSealHeaders)
+
+	req := httptest.NewRequest("GET", "/repos/owner/repo", nil)
+	req.Header.Set("Authorization", "Bearer agent-jwt-token")
+	req.Header.Set("X-Wardgate-Sealed-Authorization", sealedValue)
+	rec := httptest.NewRecorder()
+
+	p.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if receivedAuth != "Bearer ghp_realtoken" {
+		t.Errorf("expected decrypted token, got %q", receivedAuth)
+	}
+}
+
+func TestProxy_SealedMultipleHeaders(t *testing.T) {
+	var receivedAuth, receivedAPIKey string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		receivedAPIKey = r.Header.Get("X-Api-Key")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	sealer := newTestSealer(t)
+	sealedAuth, _ := sealer.Encrypt("Bearer ghp_token")
+	sealedKey, _ := sealer.Encrypt("key_12345")
+
+	vault := &mockVault{creds: map[string]string{}}
+	endpoint := config.Endpoint{
+		Upstream: upstream.URL,
+		Auth:     config.AuthConfig{Sealed: true},
+	}
+	engine := policy.New([]config.Rule{{Match: config.Match{Method: "*"}, Action: "allow"}})
+
+	p := New(endpoint, vault, engine)
+	p.SetSealer(sealer)
+	p.SetAllowedSealHeaders(DefaultAllowedSealHeaders)
+
+	req := httptest.NewRequest("GET", "/data", nil)
+	req.Header.Set("X-Wardgate-Sealed-Authorization", sealedAuth)
+	req.Header.Set("X-Wardgate-Sealed-X-Api-Key", sealedKey)
+	rec := httptest.NewRecorder()
+
+	p.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if receivedAuth != "Bearer ghp_token" {
+		t.Errorf("expected decrypted auth, got %q", receivedAuth)
+	}
+	if receivedAPIKey != "key_12345" {
+		t.Errorf("expected decrypted API key, got %q", receivedAPIKey)
+	}
+}
+
+func TestProxy_SealedMissingHeaders(t *testing.T) {
+	vault := &mockVault{creds: map[string]string{}}
+	endpoint := config.Endpoint{
+		Upstream: "http://localhost:1",
+		Auth:     config.AuthConfig{Sealed: true},
+	}
+	engine := policy.New([]config.Rule{{Match: config.Match{Method: "*"}, Action: "allow"}})
+
+	sealer := newTestSealer(t)
+	p := New(endpoint, vault, engine)
+	p.SetSealer(sealer)
+	p.SetAllowedSealHeaders(DefaultAllowedSealHeaders)
+
+	req := httptest.NewRequest("GET", "/data", nil)
+	// No X-Wardgate-Sealed-* headers
+	rec := httptest.NewRecorder()
+
+	p.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for missing sealed headers, got %d", rec.Code)
+	}
+}
+
+func TestProxy_SealedStripsAgentAuth(t *testing.T) {
+	var receivedAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	sealer := newTestSealer(t)
+	sealedValue, _ := sealer.Encrypt("Bearer upstream-token")
+
+	vault := &mockVault{creds: map[string]string{}}
+	endpoint := config.Endpoint{
+		Upstream: upstream.URL,
+		Auth:     config.AuthConfig{Sealed: true},
+	}
+	engine := policy.New([]config.Rule{{Match: config.Match{Method: "*"}, Action: "allow"}})
+
+	p := New(endpoint, vault, engine)
+	p.SetSealer(sealer)
+	p.SetAllowedSealHeaders(DefaultAllowedSealHeaders)
+
+	req := httptest.NewRequest("GET", "/data", nil)
+	req.Header.Set("Authorization", "Bearer agent-jwt")
+	req.Header.Set("X-Wardgate-Sealed-Authorization", sealedValue)
+	rec := httptest.NewRecorder()
+
+	p.ServeHTTP(rec, req)
+
+	// Should get the decrypted upstream token, not the agent JWT
+	if receivedAuth != "Bearer upstream-token" {
+		t.Errorf("expected upstream token, got %q", receivedAuth)
+	}
+}
+
+func TestProxy_SealedStripsPrefix(t *testing.T) {
+	var headers http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headers = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	sealer := newTestSealer(t)
+	sealedValue, _ := sealer.Encrypt("key-value-123")
+
+	vault := &mockVault{creds: map[string]string{}}
+	endpoint := config.Endpoint{
+		Upstream: upstream.URL,
+		Auth:     config.AuthConfig{Sealed: true},
+	}
+	engine := policy.New([]config.Rule{{Match: config.Match{Method: "*"}, Action: "allow"}})
+
+	p := New(endpoint, vault, engine)
+	p.SetSealer(sealer)
+	p.SetAllowedSealHeaders(DefaultAllowedSealHeaders)
+
+	req := httptest.NewRequest("GET", "/data", nil)
+	req.Header.Set("X-Wardgate-Sealed-X-Api-Key", sealedValue)
+	rec := httptest.NewRecorder()
+
+	p.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	// Sealed header should be stripped
+	if headers.Get("X-Wardgate-Sealed-X-Api-Key") != "" {
+		t.Error("sealed header should be stripped from upstream request")
+	}
+	// Decrypted header should be present
+	if headers.Get("X-Api-Key") != "key-value-123" {
+		t.Errorf("expected decrypted X-Api-Key header, got %q", headers.Get("X-Api-Key"))
+	}
+}
+
+func TestProxy_SealedInvalidEncryptedValue(t *testing.T) {
+	var receivedHeaders http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	sealer := newTestSealer(t)
+	validSealed, _ := sealer.Encrypt("Bearer good-token")
+
+	vault := &mockVault{creds: map[string]string{}}
+	endpoint := config.Endpoint{
+		Upstream: upstream.URL,
+		Auth:     config.AuthConfig{Sealed: true},
+	}
+	engine := policy.New([]config.Rule{{Match: config.Match{Method: "*"}, Action: "allow"}})
+
+	p := New(endpoint, vault, engine)
+	p.SetSealer(sealer)
+	p.SetAllowedSealHeaders(DefaultAllowedSealHeaders)
+
+	req := httptest.NewRequest("GET", "/data", nil)
+	// One valid sealed header, one invalid (tampered)
+	req.Header.Set("X-Wardgate-Sealed-Authorization", validSealed)
+	req.Header.Set("X-Wardgate-Sealed-X-Api-Key", "not-valid-base64!!!")
+	rec := httptest.NewRecorder()
+
+	p.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	// Valid sealed header should be decrypted and forwarded
+	if receivedHeaders.Get("Authorization") != "Bearer good-token" {
+		t.Errorf("expected valid sealed header forwarded, got %q", receivedHeaders.Get("Authorization"))
+	}
+	// Invalid sealed header should be skipped (not forwarded)
+	if receivedHeaders.Get("X-Api-Key") != "" {
+		t.Errorf("expected invalid sealed header to be skipped, got %q", receivedHeaders.Get("X-Api-Key"))
+	}
+}
+
+func TestProxy_SealedPolicyDeny(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("upstream should not be called when policy denies")
+	}))
+	defer upstream.Close()
+
+	sealer := newTestSealer(t)
+	sealedValue, _ := sealer.Encrypt("Bearer token")
+
+	vault := &mockVault{creds: map[string]string{}}
+	endpoint := config.Endpoint{
+		Upstream: upstream.URL,
+		Auth:     config.AuthConfig{Sealed: true},
+	}
+	// Policy denies DELETE
+	engine := policy.New([]config.Rule{
+		{Match: config.Match{Method: "DELETE"}, Action: "deny", Message: "no deletes"},
+	})
+
+	p := New(endpoint, vault, engine)
+	p.SetSealer(sealer)
+	p.SetAllowedSealHeaders(DefaultAllowedSealHeaders)
+
+	req := httptest.NewRequest("DELETE", "/data/123", nil)
+	req.Header.Set("X-Wardgate-Sealed-Authorization", sealedValue)
+	rec := httptest.NewRecorder()
+
+	p.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for policy deny on sealed endpoint, got %d", rec.Code)
+	}
+}
+
+func TestProxy_SealedResponseBodyForwarded(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"id": 42, "status": "created"}`))
+	}))
+	defer upstream.Close()
+
+	sealer := newTestSealer(t)
+	sealedValue, _ := sealer.Encrypt("Bearer upstream-token")
+
+	vault := &mockVault{creds: map[string]string{}}
+	endpoint := config.Endpoint{
+		Upstream: upstream.URL,
+		Auth:     config.AuthConfig{Sealed: true},
+	}
+	engine := policy.New([]config.Rule{{Match: config.Match{Method: "*"}, Action: "allow"}})
+
+	p := New(endpoint, vault, engine)
+	p.SetSealer(sealer)
+	p.SetAllowedSealHeaders(DefaultAllowedSealHeaders)
+
+	req := httptest.NewRequest("POST", "/resources", strings.NewReader(`{"name": "test"}`))
+	req.Header.Set("X-Wardgate-Sealed-Authorization", sealedValue)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	p.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Errorf("expected 201, got %d", rec.Code)
+	}
+	body, _ := io.ReadAll(rec.Body)
+	if string(body) != `{"id": 42, "status": "created"}` {
+		t.Errorf("unexpected response body: %s", body)
+	}
+	if rec.Header().Get("Content-Type") != "application/json" {
+		t.Error("Content-Type response header not forwarded")
+	}
+}
+
+func TestProxy_SealedPassesThroughRegularHeaders(t *testing.T) {
+	var receivedHeaders http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	sealer := newTestSealer(t)
+	sealedAuth, _ := sealer.Encrypt("Bearer upstream-token")
+
+	vault := &mockVault{creds: map[string]string{}}
+	endpoint := config.Endpoint{
+		Upstream: upstream.URL,
+		Auth:     config.AuthConfig{Sealed: true},
+	}
+	engine := policy.New([]config.Rule{{Match: config.Match{Method: "*"}, Action: "allow"}})
+
+	p := New(endpoint, vault, engine)
+	p.SetSealer(sealer)
+	p.SetAllowedSealHeaders(DefaultAllowedSealHeaders)
+
+	req := httptest.NewRequest("POST", "/data", nil)
+	req.Header.Set("Authorization", "Bearer agent-jwt")
+	req.Header.Set("X-Wardgate-Sealed-Authorization", sealedAuth)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("X-Request-Id", "req-123")
+	rec := httptest.NewRecorder()
+
+	p.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	// Regular headers should be forwarded unchanged
+	if receivedHeaders.Get("Content-Type") != "application/json" {
+		t.Error("Content-Type not forwarded")
+	}
+	if receivedHeaders.Get("Accept") != "application/json" {
+		t.Error("Accept not forwarded")
+	}
+	if receivedHeaders.Get("X-Request-Id") != "req-123" {
+		t.Error("X-Request-Id not forwarded")
+	}
+	// Sealed header should be replaced with decrypted value
+	if receivedHeaders.Get("Authorization") != "Bearer upstream-token" {
+		t.Errorf("expected decrypted Authorization, got %q", receivedHeaders.Get("Authorization"))
+	}
+	// Sealed prefix should be stripped
+	if receivedHeaders.Get("X-Wardgate-Sealed-Authorization") != "" {
+		t.Error("sealed header prefix should be stripped")
+	}
+}
+
+func TestProxy_SealedHeaderWhitelistAllowed(t *testing.T) {
+	var receivedAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	sealer := newTestSealer(t)
+	sealedValue, _ := sealer.Encrypt("Bearer ghp_token")
+
+	vault := &mockVault{creds: map[string]string{}}
+	endpoint := config.Endpoint{
+		Upstream: upstream.URL,
+		Auth:     config.AuthConfig{Sealed: true},
+	}
+	engine := policy.New([]config.Rule{{Match: config.Match{Method: "*"}, Action: "allow"}})
+
+	p := New(endpoint, vault, engine)
+	p.SetSealer(sealer)
+	p.SetAllowedSealHeaders([]string{"Authorization"})
+
+	req := httptest.NewRequest("GET", "/data", nil)
+	req.Header.Set("X-Wardgate-Sealed-Authorization", sealedValue)
+	rec := httptest.NewRecorder()
+
+	p.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if receivedAuth != "Bearer ghp_token" {
+		t.Errorf("expected decrypted Authorization header, got %q", receivedAuth)
+	}
+}
+
+func TestProxy_SealedHeaderWhitelistRejected(t *testing.T) {
+	var receivedHeaders http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	sealer := newTestSealer(t)
+	sealedHost, _ := sealer.Encrypt("evil.example.com")
+	sealedAuth, _ := sealer.Encrypt("Bearer good-token")
+
+	vault := &mockVault{creds: map[string]string{}}
+	endpoint := config.Endpoint{
+		Upstream: upstream.URL,
+		Auth:     config.AuthConfig{Sealed: true},
+	}
+	engine := policy.New([]config.Rule{{Match: config.Match{Method: "*"}, Action: "allow"}})
+
+	p := New(endpoint, vault, engine)
+	p.SetSealer(sealer)
+	// Only allow Authorization, not Host
+	p.SetAllowedSealHeaders([]string{"Authorization"})
+
+	req := httptest.NewRequest("GET", "/data", nil)
+	req.Header.Set("X-Wardgate-Sealed-Host", sealedHost)
+	req.Header.Set("X-Wardgate-Sealed-Authorization", sealedAuth)
+	rec := httptest.NewRecorder()
+
+	p.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	// Authorization should be forwarded (it's in the whitelist)
+	if receivedHeaders.Get("Authorization") != "Bearer good-token" {
+		t.Errorf("expected Authorization forwarded, got %q", receivedHeaders.Get("Authorization"))
+	}
+	// Sealed Host header should be stripped (not in whitelist)
+	if receivedHeaders.Get("X-Wardgate-Sealed-Host") != "" {
+		t.Error("sealed Host header should be stripped from upstream request")
+	}
+}
+
+func TestProxy_SealedHeaderDefaultWhitelist(t *testing.T) {
+	var receivedHeaders http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	sealer := newTestSealer(t)
+	sealedAuth, _ := sealer.Encrypt("Bearer token")
+	sealedKey, _ := sealer.Encrypt("key_123")
+
+	vault := &mockVault{creds: map[string]string{}}
+	endpoint := config.Endpoint{
+		Upstream: upstream.URL,
+		Auth:     config.AuthConfig{Sealed: true},
+	}
+	engine := policy.New([]config.Rule{{Match: config.Match{Method: "*"}, Action: "allow"}})
+
+	p := New(endpoint, vault, engine)
+	p.SetSealer(sealer)
+	// Empty list falls back to DefaultAllowedSealHeaders
+	p.SetAllowedSealHeaders(nil)
+
+	req := httptest.NewRequest("GET", "/data", nil)
+	req.Header.Set("X-Wardgate-Sealed-Authorization", sealedAuth)
+	req.Header.Set("X-Wardgate-Sealed-X-Api-Key", sealedKey)
+	rec := httptest.NewRecorder()
+
+	p.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	// Default whitelist should allow these
+	if receivedHeaders.Get("Authorization") != "Bearer token" {
+		t.Errorf("expected Authorization from default whitelist, got %q", receivedHeaders.Get("Authorization"))
+	}
+	if receivedHeaders.Get("X-Api-Key") != "key_123" {
+		t.Errorf("expected X-Api-Key from default whitelist, got %q", receivedHeaders.Get("X-Api-Key"))
+	}
+}
+
+func TestProxy_SealedMultipleValuesForSameHeader(t *testing.T) {
+	var receivedHeaders http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	sealer := newTestSealer(t)
+	sealedVal1, _ := sealer.Encrypt("value-one")
+	sealedVal2, _ := sealer.Encrypt("value-two")
+
+	vault := &mockVault{creds: map[string]string{}}
+	endpoint := config.Endpoint{
+		Upstream: upstream.URL,
+		Auth:     config.AuthConfig{Sealed: true},
+	}
+	engine := policy.New([]config.Rule{{Match: config.Match{Method: "*"}, Action: "allow"}})
+
+	p := New(endpoint, vault, engine)
+	p.SetSealer(sealer)
+	p.SetAllowedSealHeaders([]string{"X-Auth-Token"})
+
+	req := httptest.NewRequest("GET", "/data", nil)
+	req.Header.Add("X-Wardgate-Sealed-X-Auth-Token", sealedVal1)
+	req.Header.Add("X-Wardgate-Sealed-X-Auth-Token", sealedVal2)
+	rec := httptest.NewRecorder()
+
+	p.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	// Both decrypted values should be present
+	vals := receivedHeaders.Values("X-Auth-Token")
+	if len(vals) != 2 {
+		t.Fatalf("expected 2 values for X-Auth-Token, got %d: %v", len(vals), vals)
+	}
+	if vals[0] != "value-one" {
+		t.Errorf("expected first value 'value-one', got %q", vals[0])
+	}
+	if vals[1] != "value-two" {
+		t.Errorf("expected second value 'value-two', got %q", vals[1])
+	}
+	// Sealed prefix should be stripped
+	if receivedHeaders.Get("X-Wardgate-Sealed-X-Auth-Token") != "" {
+		t.Error("sealed header prefix should be stripped")
 	}
 }

--- a/internal/seal/seal.go
+++ b/internal/seal/seal.go
@@ -1,0 +1,132 @@
+package seal
+
+import (
+	"container/list"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"sync"
+)
+
+// DefaultCacheSize is the default number of entries in the decryption cache.
+const DefaultCacheSize = 1000
+
+type lruEntry struct {
+	key       string
+	plaintext string
+}
+
+// Sealer encrypts and decrypts values using AES-256-GCM.
+// Decrypted values are cached in a fixed-size LRU cache.
+type Sealer struct {
+	aead         cipher.AEAD
+	maxCacheSize int
+	mu           sync.Mutex
+	items        map[string]*list.Element
+	order        *list.List // front = most recent
+}
+
+// New creates a Sealer from a hex-encoded 32-byte AES key.
+// maxCacheSize controls the LRU cache capacity (0 uses DefaultCacheSize).
+func New(hexKey string, maxCacheSize int) (*Sealer, error) {
+	key, err := hex.DecodeString(hexKey)
+	if err != nil {
+		return nil, fmt.Errorf("invalid hex key: %w", err)
+	}
+	if len(key) != 32 {
+		return nil, fmt.Errorf("seal key must be 32 bytes (got %d)", len(key))
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("creating AES cipher: %w", err)
+	}
+
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("creating GCM: %w", err)
+	}
+
+	if maxCacheSize <= 0 {
+		maxCacheSize = DefaultCacheSize
+	}
+
+	return &Sealer{
+		aead:         aead,
+		maxCacheSize: maxCacheSize,
+		items:        make(map[string]*list.Element),
+		order:        list.New(),
+	}, nil
+}
+
+// Encrypt seals a plaintext string and returns a base64-encoded ciphertext.
+// Format: base64(nonce || ciphertext+tag)
+func (s *Sealer) Encrypt(plaintext string) (string, error) {
+	nonce := make([]byte, s.aead.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return "", fmt.Errorf("generating nonce: %w", err)
+	}
+
+	ciphertext := s.aead.Seal(nonce, nonce, []byte(plaintext), nil)
+	return base64.StdEncoding.EncodeToString(ciphertext), nil
+}
+
+// CacheSize returns the maximum number of entries the LRU cache can hold.
+func (s *Sealer) CacheSize() int {
+	return s.maxCacheSize
+}
+
+// Decrypt unseals a base64-encoded ciphertext and returns the plaintext.
+// Results are cached in a fixed-size LRU cache keyed by ciphertext.
+func (s *Sealer) Decrypt(sealed string) (string, error) {
+	s.mu.Lock()
+	if el, ok := s.items[sealed]; ok {
+		s.order.MoveToFront(el)
+		plaintext := el.Value.(*lruEntry).plaintext
+		s.mu.Unlock()
+		return plaintext, nil
+	}
+	s.mu.Unlock()
+
+	// Cache miss — decrypt
+	raw, err := base64.StdEncoding.DecodeString(sealed)
+	if err != nil {
+		return "", fmt.Errorf("invalid base64: %w", err)
+	}
+
+	nonceSize := s.aead.NonceSize()
+	if len(raw) < nonceSize {
+		return "", fmt.Errorf("ciphertext too short")
+	}
+
+	nonce := raw[:nonceSize]
+	ciphertext := raw[nonceSize:]
+
+	plaintext, err := s.aead.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", fmt.Errorf("decryption failed: %w", err)
+	}
+
+	// Store in cache, evict LRU if at capacity
+	s.mu.Lock()
+	// Double-check after acquiring write lock
+	if el, ok := s.items[sealed]; ok {
+		s.order.MoveToFront(el)
+		s.mu.Unlock()
+		return string(plaintext), nil
+	}
+	entry := &lruEntry{key: sealed, plaintext: string(plaintext)}
+	el := s.order.PushFront(entry)
+	s.items[sealed] = el
+	if s.order.Len() > s.maxCacheSize {
+		oldest := s.order.Back()
+		s.order.Remove(oldest)
+		delete(s.items, oldest.Value.(*lruEntry).key)
+	}
+	s.mu.Unlock()
+
+	return string(plaintext), nil
+}

--- a/internal/seal/seal_test.go
+++ b/internal/seal/seal_test.go
@@ -1,0 +1,351 @@
+package seal
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func validHexKey(t *testing.T) string {
+	t.Helper()
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatal(err)
+	}
+	return hex.EncodeToString(key)
+}
+
+func TestEncryptDecrypt(t *testing.T) {
+	s, err := New(validHexKey(t), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []string{
+		"Bearer ghp_realtoken123",
+		"key_12345",
+		"",
+		"a",
+		"hello world with spaces and special chars: !@#$%^&*()",
+	}
+
+	for _, plain := range tests {
+		sealed, err := s.Encrypt(plain)
+		if err != nil {
+			t.Fatalf("Encrypt(%q): %v", plain, err)
+		}
+
+		got, err := s.Decrypt(sealed)
+		if err != nil {
+			t.Fatalf("Decrypt(%q): %v", plain, err)
+		}
+
+		if got != plain {
+			t.Errorf("roundtrip failed: got %q, want %q", got, plain)
+		}
+	}
+}
+
+func TestEncryptProducesDifferentCiphertexts(t *testing.T) {
+	s, err := New(validHexKey(t), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a, _ := s.Encrypt("same")
+	b, _ := s.Encrypt("same")
+
+	if a == b {
+		t.Error("encrypting the same plaintext should produce different ciphertexts (random nonce)")
+	}
+}
+
+func TestInvalidKeyLength(t *testing.T) {
+	// Too short (16 bytes)
+	short := hex.EncodeToString(make([]byte, 16))
+	if _, err := New(short, 0); err == nil {
+		t.Error("expected error for 16-byte key")
+	}
+
+	// Too long (64 bytes)
+	long := hex.EncodeToString(make([]byte, 64))
+	if _, err := New(long, 0); err == nil {
+		t.Error("expected error for 64-byte key")
+	}
+
+	// Not hex
+	if _, err := New("not-hex-at-all!", 0); err == nil {
+		t.Error("expected error for non-hex key")
+	}
+}
+
+func TestTamperedCiphertext(t *testing.T) {
+	s, err := New(validHexKey(t), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sealed, err := s.Encrypt("secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Decode, flip a byte, re-encode
+	raw, _ := base64.StdEncoding.DecodeString(sealed)
+	raw[len(raw)-1] ^= 0xff
+	tampered := base64.StdEncoding.EncodeToString(raw)
+
+	if _, err := s.Decrypt(tampered); err == nil {
+		t.Error("expected error for tampered ciphertext")
+	}
+}
+
+func TestDecryptInvalidBase64(t *testing.T) {
+	s, err := New(validHexKey(t), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := s.Decrypt("not-valid-base64!!!"); err == nil {
+		t.Error("expected error for invalid base64")
+	}
+}
+
+func TestDecryptTooShort(t *testing.T) {
+	s, err := New(validHexKey(t), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	short := base64.StdEncoding.EncodeToString([]byte("abc"))
+	if _, err := s.Decrypt(short); err == nil {
+		t.Error("expected error for ciphertext shorter than nonce")
+	}
+}
+
+func TestDecryptCache(t *testing.T) {
+	s, err := New(validHexKey(t), 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sealed, _ := s.Encrypt("cached-value")
+
+	// First call — cache miss, performs decryption
+	got1, err := s.Decrypt(sealed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify entry is in cache
+	s.mu.Lock()
+	_, cached := s.items[sealed]
+	s.mu.Unlock()
+	if !cached {
+		t.Error("expected value to be cached after first Decrypt")
+	}
+
+	// Second call — should return from cache
+	got2, err := s.Decrypt(sealed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got1 != got2 || got1 != "cached-value" {
+		t.Errorf("cache returned wrong value: %q / %q", got1, got2)
+	}
+}
+
+func TestCacheEviction(t *testing.T) {
+	s, err := New(validHexKey(t), 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Fill cache with 3 entries
+	sealed := make([]string, 4)
+	for i := 0; i < 3; i++ {
+		sealed[i], _ = s.Encrypt(fmt.Sprintf("value-%d", i))
+		s.Decrypt(sealed[i])
+	}
+
+	// Cache should have exactly 3 entries
+	s.mu.Lock()
+	if len(s.items) != 3 {
+		t.Fatalf("expected 3 cached entries, got %d", len(s.items))
+	}
+	s.mu.Unlock()
+
+	// Add a 4th entry — should evict the oldest (sealed[0])
+	sealed[3], _ = s.Encrypt("value-3")
+	s.Decrypt(sealed[3])
+
+	s.mu.Lock()
+	if len(s.items) != 3 {
+		t.Fatalf("expected 3 cached entries after eviction, got %d", len(s.items))
+	}
+	_, hasFirst := s.items[sealed[0]]
+	_, hasLast := s.items[sealed[3]]
+	s.mu.Unlock()
+
+	if hasFirst {
+		t.Error("oldest entry should have been evicted")
+	}
+	if !hasLast {
+		t.Error("newest entry should be in cache")
+	}
+
+	// Evicted entry should still decrypt correctly (just not cached)
+	got, err := s.Decrypt(sealed[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "value-0" {
+		t.Errorf("expected 'value-0', got %q", got)
+	}
+}
+
+func TestCacheLRUOrdering(t *testing.T) {
+	s, err := New(validHexKey(t), 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Fill cache: [0, 1, 2] (2 is most recent)
+	sealed := make([]string, 4)
+	for i := 0; i < 3; i++ {
+		sealed[i], _ = s.Encrypt(fmt.Sprintf("value-%d", i))
+		s.Decrypt(sealed[i])
+	}
+
+	// Access sealed[0] to make it most recent: order becomes [1, 2, 0]
+	s.Decrypt(sealed[0])
+
+	// Add a 4th entry — should evict sealed[1] (now the LRU)
+	sealed[3], _ = s.Encrypt("value-3")
+	s.Decrypt(sealed[3])
+
+	s.mu.Lock()
+	_, hasZero := s.items[sealed[0]]
+	_, hasOne := s.items[sealed[1]]
+	_, hasThree := s.items[sealed[3]]
+	s.mu.Unlock()
+
+	if !hasZero {
+		t.Error("sealed[0] was recently accessed, should not be evicted")
+	}
+	if hasOne {
+		t.Error("sealed[1] was LRU, should be evicted")
+	}
+	if !hasThree {
+		t.Error("sealed[3] is newest, should be in cache")
+	}
+}
+
+func TestCacheDefaultSize(t *testing.T) {
+	s, err := New(validHexKey(t), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.maxCacheSize != DefaultCacheSize {
+		t.Errorf("expected default cache size %d, got %d", DefaultCacheSize, s.maxCacheSize)
+	}
+}
+
+func TestCacheSizeCustom(t *testing.T) {
+	s, err := New(validHexKey(t), 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.CacheSize() != 42 {
+		t.Errorf("expected cache size 42, got %d", s.CacheSize())
+	}
+}
+
+func TestNegativeCacheSize(t *testing.T) {
+	s, err := New(validHexKey(t), -5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.maxCacheSize != DefaultCacheSize {
+		t.Errorf("negative cache size should default to %d, got %d", DefaultCacheSize, s.maxCacheSize)
+	}
+}
+
+func TestDecryptWrongKey(t *testing.T) {
+	s1, err := New(validHexKey(t), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s2, err := New(validHexKey(t), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sealed, err := s1.Encrypt("secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Decrypting with a different key should fail
+	if _, err := s2.Decrypt(sealed); err == nil {
+		t.Error("expected error when decrypting with wrong key")
+	}
+}
+
+func TestEncryptEmpty(t *testing.T) {
+	s, err := New(validHexKey(t), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sealed, err := s.Encrypt("")
+	if err != nil {
+		t.Fatalf("Encrypt empty: %v", err)
+	}
+
+	got, err := s.Decrypt(sealed)
+	if err != nil {
+		t.Fatalf("Decrypt empty: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
+func TestConcurrentDecrypt(t *testing.T) {
+	s, err := New(validHexKey(t), 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sealed, _ := s.Encrypt("concurrent")
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 100)
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			got, err := s.Decrypt(sealed)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if got != "concurrent" {
+				errs <- fmt.Errorf("got %q, want 'concurrent'", got)
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
## Summary

- Agents can carry their own encrypted API keys as `X-Wardgate-Sealed-*` headers. Wardgate strips the prefix, decrypts via AES-256-GCM, and forwards the real values to upstream services.
- New `internal/seal` package with AES-256-GCM encrypt/decrypt and fixed-size LRU decryption cache
- Config support: `server.seal` (`key_env`, `cache_size`, `allowed_headers`) and per-endpoint `auth.sealed: true`
- Proxy processes sealed headers in the reverse proxy Director, strips agent auth, forwards decrypted values
- **Header whitelist**: configurable `allowed_headers` in `server.seal` prevents agents from manipulating arbitrary headers (e.g. `Host`, `Cookie`). Conservative defaults: `Authorization`, `X-Api-Key`, `X-Auth-Token`, `Proxy-Authorization`
- **Multi-value support**: multiple sealed values for the same header are all decrypted and forwarded via `Header.Add`
- CLI `wardgate seal` subcommand with `--key-env` flag for specifying the env var name; falls back to `server.seal.key_env` from config when flag is omitted
- Documentation in `docs/sealed-credentials.md` with setup guide, config reference, header whitelist section, and security considerations (including no replay protection note)

## Changes since initial review

Addresses all feedback from @avoutic:

1. **`wardgate seal` CLI** — added `--key-env` flag and config fallback instead of hardcoding `WARDGATE_SEAL_KEY` ([comment](https://github.com/wardgate/wardgate/pull/2#discussion_r2845724848))
2. **No reuse protection** — documented in Security Considerations section ([comment](https://github.com/wardgate/wardgate/pull/2#discussion_r2845750445))
3. **Header whitelist** — added `allowed_headers` config to prevent agents from sealing arbitrary headers like `Host` ([comment](https://github.com/wardgate/wardgate/pull/2#discussion_r2845780404))
4. **DCO sign-off** — included
5. **Rebased** on current main

## Test plan

- [x] Unit tests for `internal/seal` (roundtrip, invalid key, tampered ciphertext, cache eviction, LRU ordering, concurrent access)
- [x] Unit tests for `internal/config` (sealed validation, mutual exclusivity with credential_env, missing server.seal, cache_size, allowed_headers parsing)
- [x] Unit tests for `internal/proxy` (sealed header forwarding, multiple headers, multiple values for same header, missing headers, policy deny, invalid values, regular header passthrough, response forwarding, whitelist allowed, whitelist rejected, default whitelist)
- [x] E2E integration test in `e2e/` wiring auth middleware + policy engine + proxy + sealer + mock upstream (9 subtests covering auth, policy, decryption, header stripping, body forwarding, error handling)
- [x] Full test suite passes: `go test -race -count=1 ./...` (22 packages, 0 failures)
- [x] `go build ./...` and `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)