### PR TITLE
feat: Add wardgate-proxy with key/key_env config aligned to wardgate-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ grants.json
 /wardgate
 /wardgate-cli
 /wardgate-exec
+/wardgate-proxy
 /config/
 
 # Zensical

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,6 +56,24 @@ builds:
       - -X main.commit={{.Commit}}
       - -X main.date={{.Date}}
 
+  - id: wardgate-proxy
+    main: ./cmd/wardgate-proxy
+    binary: wardgate-proxy
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+
 archives:
   - id: wardgate
     ids:
@@ -88,6 +106,18 @@ archives:
       - wardgate-exec
     formats: [tar.gz]
     name_template: "wardgate-exec_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    files:
+      - README.md
+      - LICENSE
+
+  - id: wardgate-proxy
+    ids:
+      - wardgate-proxy
+    formats: [tar.gz]
+    name_template: "wardgate-proxy_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows
         formats: [zip]
@@ -158,6 +188,18 @@ brews:
     license: "AGPL-3.0"
     install: |
       bin.install "wardgate-exec"
+
+  - name: wardgate-proxy
+    ids: [wardgate-proxy]
+    repository:
+      owner: wardgate
+      name: homebrew-wardgate
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    homepage: "https://github.com/wardgate/wardgate"
+    description: "API gateway for AI agents - local reverse proxy"
+    license: "AGPL-3.0"
+    install: |
+      bin.install "wardgate-proxy"
 
 release:
   github:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,6 +6,7 @@ Wardgate has three binaries:
 |--------|---------|
 | `wardgate` | The gateway server -- proxies API calls and routes conclave commands |
 | `wardgate-cli` | Agent-side tool -- restricted HTTP client and conclave exec; replaces `curl` |
+| `wardgate-proxy` | Local reverse proxy for sandboxed agents that use their own HTTP clients -- injects the agent key transparently without requiring shell access or restarts |
 | `wardgate-exec` | Runs inside each conclave -- connects to Wardgate, executes commands |
 
 ## Homebrew (macOS / Linux)
@@ -40,6 +41,7 @@ Requires Go 1.22+.
 ```bash
 go install github.com/wardgate/wardgate/cmd/wardgate@latest
 go install github.com/wardgate/wardgate/cmd/wardgate-cli@latest
+go install github.com/wardgate/wardgate/cmd/wardgate-proxy@latest
 go install github.com/wardgate/wardgate/cmd/wardgate-exec@latest
 ```
 
@@ -55,6 +57,7 @@ cd wardgate
 
 go build -o wardgate ./cmd/wardgate
 go build -o wardgate-cli ./cmd/wardgate-cli
+go build -o wardgate-proxy ./cmd/wardgate-proxy
 go build -o wardgate-exec ./cmd/wardgate-exec
 ```
 
@@ -135,6 +138,35 @@ ca_file: /etc/wardgate-cli/ca.pem
 - The config path is fixed at build time -- agents cannot override it
 
 See [wardgate-cli documentation](docs/wardgate-cli.md) for full details. To teach an AI agent how to use `wardgate-cli`, copy the [wardgate-cli AI Skill](skills/wardgate-cli/SKILL.md) into your agent's skill/tool directory.
+
+## wardgate-proxy Setup
+
+`wardgate-proxy` is a local reverse proxy for agents that use their own HTTP clients (Python `requests`, Node `fetch`, etc.). The agent makes plain HTTP requests to the proxy, and the proxy forwards them to Wardgate with the agent key injected.
+
+Create a config file (default: `wardgate-proxy.yaml`):
+
+```yaml
+server: https://wardgate.example.com
+key: "your-agent-key"
+listen: 127.0.0.1:18080
+```
+
+Or with the key in an environment variable:
+
+```yaml
+server: https://wardgate.example.com
+key_env: WARDGATE_AGENT_KEY
+```
+
+Start the proxy:
+
+```bash
+wardgate-proxy
+```
+
+The agent sends requests to `http://127.0.0.1:18080/...` and the proxy injects the agent key and forwards to Wardgate. When using `key` in the config, rotation is automatic -- update the key in the config file and the proxy picks it up on the next request.
+
+See [wardgate-proxy documentation](docs/wardgate-proxy.md) for full details.
 
 ## wardgate-exec / Conclave Setup
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ flowchart LR
 - **Anomaly Detection** -- Alert on unusual patterns (suddenly fetching 100 emails, or things from the past?)
 - **Admin UI & CLI** -- Web dashboard and CLI for managing approvals, viewing logs, and monitoring activity
 - **wardgate-cli** -- Restricted HTTP client and conclave exec tool for agents; replaces `curl` and prevents connections to arbitrary URLs
+- **wardgate-proxy** -- Local reverse proxy for agents that use their own HTTP clients; injects the agent key transparently
 
 ## Who Is This For?
 
@@ -173,6 +174,7 @@ See [INSTALL.md](INSTALL.md) for all installation methods (pre-built binaries, D
 - [Configuration Reference](docs/config.md) -- All configuration options
 - [Conclaves](docs/conclaves.md) -- Isolated remote execution environments
 - [wardgate-cli](docs/wardgate-cli.md) -- Restricted HTTP client and conclave exec for agents
+- [wardgate-proxy](docs/wardgate-proxy.md) -- Local reverse proxy for agents with their own HTTP clients
 - [wardgate-cli AI Skill](skills/wardgate-cli/SKILL.md) -- Skill file to teach AI agents how to use wardgate-cli
 - [Deployment Guide](docs/deployment.md) -- Docker, Caddy, and production setup
 

--- a/cmd/wardgate-proxy/main.go
+++ b/cmd/wardgate-proxy/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"flag"
 	"fmt"
 	"log"
@@ -17,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/wardgate/wardgate/internal/cli"
 	"gopkg.in/yaml.v3"
 )
 
@@ -132,24 +132,12 @@ func (cr *configKeyReader) Read() (string, error) {
 }
 
 func buildTransport(caFile string) (*http.Transport, error) {
-	tlsCfg := &tls.Config{}
-
-	if caFile != "" {
-		pem, err := os.ReadFile(caFile)
-		if err != nil {
-			return nil, fmt.Errorf("read ca_file: %w", err)
-		}
-		pool, err := x509.SystemCertPool()
-		if err != nil {
-			pool = x509.NewCertPool()
-		}
-		if !pool.AppendCertsFromPEM(pem) {
-			return nil, fmt.Errorf("ca_file: no valid PEM certificates")
-		}
-		tlsCfg.RootCAs = pool
+	cliCfg := &cli.Config{CAFile: caFile}
+	rootCAs, err := cliCfg.LoadRootCAs()
+	if err != nil {
+		return nil, err
 	}
-
-	return &http.Transport{TLSClientConfig: tlsCfg}, nil
+	return &http.Transport{TLSClientConfig: &tls.Config{RootCAs: rootCAs}}, nil
 }
 
 // NewProxyHandler builds an http.Handler that reads an agent key from keyReader
@@ -188,16 +176,16 @@ type contextKey string
 const ctxAgentKey contextKey = "agentKey"
 
 // resolveConfig loads the config file and applies flag overrides.
-func resolveConfig(configPath string, configExplicit bool, listen, server, keyEnv string) *Config {
+func resolveConfig(configPath string, configExplicit bool, listen, server, keyEnv string) (*Config, error) {
 	cfg := &Config{Listen: "127.0.0.1:18080"}
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if configExplicit {
-			log.Fatalf("Error: config file %s not found", configPath)
+			return nil, fmt.Errorf("config file %s not found", configPath)
 		}
 	} else {
 		if err := yaml.Unmarshal(data, cfg); err != nil {
-			log.Fatalf("Error parsing config %s: %v", configPath, err)
+			return nil, fmt.Errorf("parsing config %s: %w", configPath, err)
 		}
 	}
 
@@ -215,12 +203,12 @@ func resolveConfig(configPath string, configExplicit bool, listen, server, keyEn
 		cfg.Listen = "127.0.0.1:18080"
 	}
 	if cfg.Server == "" {
-		log.Fatal("Error: server URL not configured (set server in config or use -server flag)")
+		return nil, fmt.Errorf("server URL not configured (set server in config or use -server flag)")
 	}
 	if cfg.Key == "" && cfg.KeyEnv == "" {
-		log.Fatal("Error: agent key not configured (set key or key_env in config, or use -key-env flag)")
+		return nil, fmt.Errorf("agent key not configured (set key or key_env in config, or use -key-env flag)")
 	}
-	return cfg
+	return cfg, nil
 }
 
 func main() {
@@ -243,7 +231,10 @@ func main() {
 		}
 	})
 
-	cfg := resolveConfig(*configPath, configExplicit, *listenFlag, *serverFlag, *keyEnvFlag)
+	cfg, err := resolveConfig(*configPath, configExplicit, *listenFlag, *serverFlag, *keyEnvFlag)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
 
 	upstream, err := url.Parse(cfg.Server)
 	if err != nil {

--- a/cmd/wardgate-proxy/main.go
+++ b/cmd/wardgate-proxy/main.go
@@ -1,0 +1,304 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+// Config holds wardgate-proxy configuration.
+type Config struct {
+	Server string `yaml:"server"`
+	Key    string `yaml:"key"`
+	KeyEnv string `yaml:"key_env"`
+	Listen string `yaml:"listen"`
+	CAFile string `yaml:"ca_file"`
+}
+
+// KeyReader returns the current agent key.
+type KeyReader interface {
+	Read() (string, error)
+}
+
+// staticKeyReader holds a resolved key for the process lifetime (key_env mode).
+type staticKeyReader struct {
+	key string
+}
+
+func (s *staticKeyReader) Read() (string, error) {
+	return s.key, nil
+}
+
+// configKeyReader watches the config file's mtime and re-reads the key field
+// on change. On re-read failure, it falls back to the cached key.
+type configKeyReader struct {
+	configPath string
+	mu         sync.RWMutex
+	key        string
+	mtime      time.Time
+}
+
+func newConfigKeyReader(configPath string) *configKeyReader {
+	return &configKeyReader{configPath: configPath}
+}
+
+// Read returns the current key, re-reading from the config file if mtime changed.
+func (cr *configKeyReader) Read() (string, error) {
+	info, err := os.Stat(cr.configPath)
+	if err != nil {
+		cr.mu.RLock()
+		if cr.key != "" {
+			defer cr.mu.RUnlock()
+			log.Printf("Warning: cannot stat config file, using cached key: %v", err)
+			return cr.key, nil
+		}
+		cr.mu.RUnlock()
+		return "", fmt.Errorf("stat config file: %w", err)
+	}
+
+	cr.mu.RLock()
+	if cr.key != "" && info.ModTime().Equal(cr.mtime) {
+		defer cr.mu.RUnlock()
+		return cr.key, nil
+	}
+	cr.mu.RUnlock()
+
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
+
+	// Double-check after acquiring write lock.
+	info2, err := os.Stat(cr.configPath)
+	if err != nil {
+		if cr.key != "" {
+			log.Printf("Warning: cannot stat config file, using cached key: %v", err)
+			return cr.key, nil
+		}
+		return "", fmt.Errorf("stat config file: %w", err)
+	}
+	if cr.key != "" && info2.ModTime().Equal(cr.mtime) {
+		return cr.key, nil
+	}
+
+	data, err := os.ReadFile(cr.configPath)
+	if err != nil {
+		if cr.key != "" {
+			log.Printf("Warning: cannot read config file, using cached key: %v", err)
+			return cr.key, nil
+		}
+		return "", fmt.Errorf("read config file: %w", err)
+	}
+
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		if cr.key != "" {
+			log.Printf("Warning: cannot parse config file, using cached key: %v", err)
+			return cr.key, nil
+		}
+		return "", fmt.Errorf("parse config file: %w", err)
+	}
+
+	key := strings.TrimSpace(cfg.Key)
+	if key == "" {
+		if cr.key != "" {
+			log.Printf("Warning: config file has empty key, using cached key")
+			return cr.key, nil
+		}
+		return "", fmt.Errorf("config file has empty key")
+	}
+
+	cr.key = key
+	cr.mtime = info2.ModTime()
+	return key, nil
+}
+
+func buildTransport(caFile string) (*http.Transport, error) {
+	tlsCfg := &tls.Config{}
+
+	if caFile != "" {
+		pem, err := os.ReadFile(caFile)
+		if err != nil {
+			return nil, fmt.Errorf("read ca_file: %w", err)
+		}
+		pool, err := x509.SystemCertPool()
+		if err != nil {
+			pool = x509.NewCertPool()
+		}
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("ca_file: no valid PEM certificates")
+		}
+		tlsCfg.RootCAs = pool
+	}
+
+	return &http.Transport{TLSClientConfig: tlsCfg}, nil
+}
+
+// NewProxyHandler builds an http.Handler that reads an agent key from keyReader
+// and forwards every request to upstream with that key injected.
+func NewProxyHandler(upstream *url.URL, keyReader KeyReader, transport http.RoundTripper) http.Handler {
+	rp := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			key := req.Context().Value(ctxAgentKey).(string)
+
+			req.URL.Scheme = upstream.Scheme
+			req.URL.Host = upstream.Host
+			req.Host = upstream.Host
+			req.Header.Set("Authorization", "Bearer "+key)
+			req.Header.Del("X-Forwarded-For")
+		},
+		FlushInterval: -1, // flush immediately for SSE and streaming
+		Transport:     transport,
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			http.Error(w, fmt.Sprintf("proxy error: %v", err), http.StatusBadGateway)
+		},
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key, err := keyReader.Read()
+		if err != nil {
+			http.Error(w, fmt.Sprintf("key error: %v", err), http.StatusBadGateway)
+			return
+		}
+		ctx := context.WithValue(r.Context(), ctxAgentKey, key)
+		rp.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+type contextKey string
+
+const ctxAgentKey contextKey = "agentKey"
+
+// resolveConfig loads the config file and applies flag overrides.
+func resolveConfig(configPath string, configExplicit bool, listen, server, keyEnv string) *Config {
+	cfg := &Config{Listen: "127.0.0.1:18080"}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if configExplicit {
+			log.Fatalf("Error: config file %s not found", configPath)
+		}
+	} else {
+		if err := yaml.Unmarshal(data, cfg); err != nil {
+			log.Fatalf("Error parsing config %s: %v", configPath, err)
+		}
+	}
+
+	if listen != "" {
+		cfg.Listen = listen
+	}
+	if server != "" {
+		cfg.Server = server
+	}
+	if keyEnv != "" {
+		cfg.KeyEnv = keyEnv
+	}
+
+	if cfg.Listen == "" {
+		cfg.Listen = "127.0.0.1:18080"
+	}
+	if cfg.Server == "" {
+		log.Fatal("Error: server URL not configured (set server in config or use -server flag)")
+	}
+	if cfg.Key == "" && cfg.KeyEnv == "" {
+		log.Fatal("Error: agent key not configured (set key or key_env in config, or use -key-env flag)")
+	}
+	return cfg
+}
+
+func main() {
+	configPath := flag.String("config", "wardgate-proxy.yaml", "Path to config file")
+	listenFlag := flag.String("listen", "", "Listen address (overrides config)")
+	serverFlag := flag.String("server", "", "Wardgate server URL (overrides config)")
+	keyEnvFlag := flag.String("key-env", "", "Environment variable containing agent key (overrides config)")
+	showVersion := flag.Bool("version", false, "Show version and exit")
+	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("wardgate-proxy %s (commit: %s, built: %s)\n", version, commit, date)
+		os.Exit(0)
+	}
+
+	configExplicit := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "config" {
+			configExplicit = true
+		}
+	})
+
+	cfg := resolveConfig(*configPath, configExplicit, *listenFlag, *serverFlag, *keyEnvFlag)
+
+	upstream, err := url.Parse(cfg.Server)
+	if err != nil {
+		log.Fatalf("Error: invalid server URL: %v", err)
+	}
+	if upstream.Scheme == "" || upstream.Host == "" {
+		log.Fatal("Error: server URL must include scheme and host (e.g. https://gateway.example.com)")
+	}
+
+	transport, err := buildTransport(cfg.CAFile)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Create the appropriate key reader.
+	var keyReader KeyReader
+	if cfg.Key != "" {
+		keyReader = newConfigKeyReader(*configPath)
+	} else {
+		// cfg.KeyEnv is set (validated by resolveConfig).
+		resolved := os.Getenv(cfg.KeyEnv)
+		if resolved == "" {
+			log.Fatalf("Error: environment variable %s is empty", cfg.KeyEnv)
+		}
+		keyReader = &staticKeyReader{key: resolved}
+	}
+
+	// Validate the key is readable at startup.
+	if _, err := keyReader.Read(); err != nil {
+		log.Fatalf("Error: cannot read agent key: %v", err)
+	}
+
+	handler := NewProxyHandler(upstream, keyReader, transport)
+
+	srv := &http.Server{
+		Addr:    cfg.Listen,
+		Handler: handler,
+	}
+
+	done := make(chan os.Signal, 1)
+	signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		log.Printf("wardgate-proxy listening on %s -> %s", cfg.Listen, cfg.Server)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("Error: %v", err)
+		}
+	}()
+
+	<-done
+	log.Println("Shutting down...")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		log.Fatalf("Error during shutdown: %v", err)
+	}
+}

--- a/cmd/wardgate-proxy/main_test.go
+++ b/cmd/wardgate-proxy/main_test.go
@@ -1,0 +1,896 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// --- staticKeyReader tests ---
+
+func TestStaticKeyReader(t *testing.T) {
+	r := &staticKeyReader{key: "my-key"}
+	key, err := r.Read()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key != "my-key" {
+		t.Fatalf("got %q, want %q", key, "my-key")
+	}
+
+	// Second read returns the same value.
+	key2, err := r.Read()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key2 != "my-key" {
+		t.Fatalf("got %q, want %q", key2, "my-key")
+	}
+}
+
+// --- configKeyReader tests ---
+
+func TestConfigKeyReader_ReadsKey(t *testing.T) {
+	path := writeKeyFile(t, "my-agent-key")
+	cr := newConfigKeyReader(path)
+
+	key, err := cr.Read()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key != "my-agent-key" {
+		t.Fatalf("got %q, want %q", key, "my-agent-key")
+	}
+}
+
+func TestConfigKeyReader_TrimsWhitespace(t *testing.T) {
+	path := writeKeyFile(t, "  key-with-spaces ")
+	cr := newConfigKeyReader(path)
+
+	key, err := cr.Read()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key != "key-with-spaces" {
+		t.Fatalf("got %q, want %q", key, "key-with-spaces")
+	}
+}
+
+func TestConfigKeyReader_EmptyKeyError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte("server: https://example.com\nkey: \"\"\n"), 0o600)
+
+	cr := newConfigKeyReader(path)
+	_, err := cr.Read()
+	if err == nil {
+		t.Fatal("expected error for empty key")
+	}
+	if !strings.Contains(err.Error(), "empty key") {
+		t.Fatalf("expected empty key error, got: %v", err)
+	}
+}
+
+func TestConfigKeyReader_MissingFileError(t *testing.T) {
+	cr := newConfigKeyReader("/nonexistent/config.yaml")
+
+	_, err := cr.Read()
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestConfigKeyReader_CachesByMtime(t *testing.T) {
+	path := writeKeyFile(t, "key-v1")
+	cr := newConfigKeyReader(path)
+
+	k1, err := cr.Read()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if k1 != "key-v1" {
+		t.Fatalf("got %q, want %q", k1, "key-v1")
+	}
+
+	// Record the original mtime.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	origMtime := info.ModTime()
+
+	// Overwrite file with different content, then restore original mtime.
+	writeKeyFileAt(t, path, "key-v2-should-not-see")
+	os.Chtimes(path, origMtime, origMtime)
+
+	// Read again -- same mtime means the cache should return "key-v1".
+	k2, err := cr.Read()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if k2 != "key-v1" {
+		t.Fatalf("got %q, want %q (cache was not used)", k2, "key-v1")
+	}
+}
+
+func TestConfigKeyReader_DetectsRotation(t *testing.T) {
+	path := writeKeyFile(t, "key-v1")
+	cr := newConfigKeyReader(path)
+
+	k1, _ := cr.Read()
+	if k1 != "key-v1" {
+		t.Fatalf("got %q, want %q", k1, "key-v1")
+	}
+
+	// Ensure mtime changes (some filesystems have 1s resolution).
+	time.Sleep(10 * time.Millisecond)
+	writeKeyFileAt(t, path, "key-v2")
+
+	// Force mtime to be different.
+	future := time.Now().Add(2 * time.Second)
+	os.Chtimes(path, future, future)
+
+	k2, _ := cr.Read()
+	if k2 != "key-v2" {
+		t.Fatalf("got %q, want %q", k2, "key-v2")
+	}
+}
+
+func TestConfigKeyReader_FallbackOnPartialWrite(t *testing.T) {
+	path := writeKeyFile(t, "good-key")
+	cr := newConfigKeyReader(path)
+
+	// First read succeeds and caches.
+	k1, err := cr.Read()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if k1 != "good-key" {
+		t.Fatalf("got %q, want %q", k1, "good-key")
+	}
+
+	// Simulate a half-written file: valid YAML but empty key.
+	os.WriteFile(path, []byte("server: https://example.com\nkey: \"\"\n"), 0o600)
+	future := time.Now().Add(2 * time.Second)
+	os.Chtimes(path, future, future)
+
+	// Should fall back to cached key.
+	k2, err := cr.Read()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if k2 != "good-key" {
+		t.Fatalf("got %q, want %q (expected fallback to cached key)", k2, "good-key")
+	}
+
+	// Simulate invalid YAML.
+	os.WriteFile(path, []byte("{{{invalid"), 0o600)
+	future2 := time.Now().Add(4 * time.Second)
+	os.Chtimes(path, future2, future2)
+
+	// Should still fall back to cached key.
+	k3, err := cr.Read()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if k3 != "good-key" {
+		t.Fatalf("got %q, want %q (expected fallback to cached key)", k3, "good-key")
+	}
+}
+
+func TestConfigKeyReader_ConcurrentAccess(t *testing.T) {
+	path := writeKeyFile(t, "concurrent-key")
+	cr := newConfigKeyReader(path)
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 50)
+	for i := range 50 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key, err := cr.Read()
+			if err != nil {
+				errs <- err
+				return
+			}
+			if key != "concurrent-key" {
+				errs <- fmt.Errorf("goroutine %d: got %q", i, key)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Errorf("concurrent error: %v", err)
+	}
+}
+
+// --- Config loading tests ---
+
+func loadConfig(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+	return &cfg, nil
+}
+
+func TestLoadConfig_ValidYAML(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	os.WriteFile(cfgPath, []byte(`
+server: https://gateway.example.com
+key: my-agent-key
+listen: 127.0.0.1:9090
+ca_file: /etc/ca.pem
+`), 0o600)
+
+	cfg, err := loadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Server != "https://gateway.example.com" {
+		t.Errorf("server: got %q", cfg.Server)
+	}
+	if cfg.Key != "my-agent-key" {
+		t.Errorf("key: got %q", cfg.Key)
+	}
+	if cfg.Listen != "127.0.0.1:9090" {
+		t.Errorf("listen: got %q", cfg.Listen)
+	}
+	if cfg.CAFile != "/etc/ca.pem" {
+		t.Errorf("ca_file: got %q", cfg.CAFile)
+	}
+}
+
+func TestLoadConfig_KeyEnv(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	os.WriteFile(cfgPath, []byte(`
+server: https://gateway.example.com
+key_env: WARDGATE_AGENT_KEY
+`), 0o600)
+
+	cfg, err := loadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.KeyEnv != "WARDGATE_AGENT_KEY" {
+		t.Errorf("key_env: got %q", cfg.KeyEnv)
+	}
+}
+
+func TestLoadConfig_MissingFile(t *testing.T) {
+	_, err := loadConfig("/nonexistent/config.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing config")
+	}
+}
+
+func TestLoadConfig_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "bad.yaml")
+	os.WriteFile(cfgPath, []byte(`{{{invalid`), 0o600)
+
+	_, err := loadConfig(cfgPath)
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+}
+
+// --- Proxy handler unit tests ---
+
+func TestProxyHandler_InjectsBearer(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer test-agent-key" {
+			t.Errorf("got Authorization %q, want %q", auth, "Bearer test-agent-key")
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	u, _ := url.Parse(upstream.URL)
+	handler := NewProxyHandler(u, &staticKeyReader{key: "test-agent-key"}, http.DefaultTransport)
+	proxy := httptest.NewServer(handler)
+	defer proxy.Close()
+
+	resp, err := http.Get(proxy.URL + "/some/path")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("got status %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "ok" {
+		t.Errorf("got body %q, want %q", string(body), "ok")
+	}
+}
+
+func TestProxyHandler_ForwardsPath(t *testing.T) {
+	var gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	u, _ := url.Parse(upstream.URL)
+	handler := NewProxyHandler(u, &staticKeyReader{key: "tok"}, http.DefaultTransport)
+	proxy := httptest.NewServer(handler)
+	defer proxy.Close()
+
+	http.Get(proxy.URL + "/github/repos?page=2")
+
+	if gotPath != "/github/repos" {
+		t.Errorf("got path %q, want %q", gotPath, "/github/repos")
+	}
+}
+
+func TestProxyHandler_ForwardsQueryParams(t *testing.T) {
+	var gotQuery string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	u, _ := url.Parse(upstream.URL)
+	handler := NewProxyHandler(u, &staticKeyReader{key: "tok"}, http.DefaultTransport)
+	proxy := httptest.NewServer(handler)
+	defer proxy.Close()
+
+	http.Get(proxy.URL + "/endpoint?key=value&foo=bar")
+
+	if gotQuery != "key=value&foo=bar" {
+		t.Errorf("got query %q, want %q", gotQuery, "key=value&foo=bar")
+	}
+}
+
+func TestProxyHandler_ForwardsMethod(t *testing.T) {
+	var gotMethod string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	u, _ := url.Parse(upstream.URL)
+	handler := NewProxyHandler(u, &staticKeyReader{key: "tok"}, http.DefaultTransport)
+	proxy := httptest.NewServer(handler)
+	defer proxy.Close()
+
+	req, _ := http.NewRequest(http.MethodDelete, proxy.URL+"/resource/123", nil)
+	http.DefaultClient.Do(req)
+
+	if gotMethod != http.MethodDelete {
+		t.Errorf("got method %q, want DELETE", gotMethod)
+	}
+}
+
+func TestProxyHandler_ForwardsRequestBody(t *testing.T) {
+	var gotBody string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	u, _ := url.Parse(upstream.URL)
+	handler := NewProxyHandler(u, &staticKeyReader{key: "tok"}, http.DefaultTransport)
+	proxy := httptest.NewServer(handler)
+	defer proxy.Close()
+
+	http.Post(proxy.URL+"/data", "application/json", strings.NewReader(`{"key":"value"}`))
+
+	if gotBody != `{"key":"value"}` {
+		t.Errorf("got body %q", gotBody)
+	}
+}
+
+func TestProxyHandler_ForwardsCustomHeaders(t *testing.T) {
+	var gotHeader string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("X-Custom-Header")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	u, _ := url.Parse(upstream.URL)
+	handler := NewProxyHandler(u, &staticKeyReader{key: "tok"}, http.DefaultTransport)
+	proxy := httptest.NewServer(handler)
+	defer proxy.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, proxy.URL+"/test", nil)
+	req.Header.Set("X-Custom-Header", "custom-value")
+	http.DefaultClient.Do(req)
+
+	if gotHeader != "custom-value" {
+		t.Errorf("got header %q, want %q", gotHeader, "custom-value")
+	}
+}
+
+func TestProxyHandler_StripsAgentAuth(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	u, _ := url.Parse(upstream.URL)
+	handler := NewProxyHandler(u, &staticKeyReader{key: "proxy-key"}, http.DefaultTransport)
+	proxy := httptest.NewServer(handler)
+	defer proxy.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, proxy.URL+"/test", nil)
+	req.Header.Set("Authorization", "Bearer agent-should-be-overwritten")
+	http.DefaultClient.Do(req)
+
+	if gotAuth != "Bearer proxy-key" {
+		t.Errorf("got auth %q, want %q", gotAuth, "Bearer proxy-key")
+	}
+}
+
+func TestProxyHandler_Returns502OnKeyError(t *testing.T) {
+	cr := newConfigKeyReader("/nonexistent/config.yaml")
+	u, _ := url.Parse("http://localhost:1")
+	handler := NewProxyHandler(u, cr, http.DefaultTransport)
+	proxy := httptest.NewServer(handler)
+	defer proxy.Close()
+
+	resp, err := http.Get(proxy.URL + "/test")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Errorf("got status %d, want 502", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "key error") {
+		t.Errorf("expected key error in body, got: %s", body)
+	}
+}
+
+func TestProxyHandler_Returns502OnUpstreamDown(t *testing.T) {
+	u, _ := url.Parse("http://127.0.0.1:1") // nothing listening
+	handler := NewProxyHandler(u, &staticKeyReader{key: "valid-key"}, http.DefaultTransport)
+	proxy := httptest.NewServer(handler)
+	defer proxy.Close()
+
+	resp, err := http.Get(proxy.URL + "/test")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Errorf("got status %d, want 502", resp.StatusCode)
+	}
+}
+
+func TestProxyHandler_ReturnsUpstreamStatus(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte("denied"))
+	}))
+	defer upstream.Close()
+
+	u, _ := url.Parse(upstream.URL)
+	handler := NewProxyHandler(u, &staticKeyReader{key: "tok"}, http.DefaultTransport)
+	proxy := httptest.NewServer(handler)
+	defer proxy.Close()
+
+	resp, err := http.Get(proxy.URL + "/test")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("got status %d, want 403", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "denied" {
+		t.Errorf("got body %q, want %q", string(body), "denied")
+	}
+}
+
+// --- SSE / Streaming tests ---
+
+func TestProxyHandler_StreamsSSE(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("server does not support flushing")
+		}
+		for i := range 3 {
+			fmt.Fprintf(w, "data: event-%d\n\n", i)
+			flusher.Flush()
+			time.Sleep(10 * time.Millisecond)
+		}
+	}))
+	defer upstream.Close()
+
+	u, _ := url.Parse(upstream.URL)
+	handler := NewProxyHandler(u, &staticKeyReader{key: "sse-key"}, http.DefaultTransport)
+	proxy := httptest.NewServer(handler)
+	defer proxy.Close()
+
+	resp, err := http.Get(proxy.URL + "/events")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.Header.Get("Content-Type") != "text/event-stream" {
+		t.Errorf("got content-type %q, want text/event-stream", resp.Header.Get("Content-Type"))
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	for i := range 3 {
+		expected := fmt.Sprintf("data: event-%d", i)
+		if !strings.Contains(string(body), expected) {
+			t.Errorf("missing SSE event %q in body: %s", expected, body)
+		}
+	}
+}
+
+func TestProxyHandler_StreamsChunked(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("no flusher")
+		}
+		for i := range 5 {
+			fmt.Fprintf(w, "chunk-%d\n", i)
+			flusher.Flush()
+			time.Sleep(5 * time.Millisecond)
+		}
+	}))
+	defer upstream.Close()
+
+	u, _ := url.Parse(upstream.URL)
+	handler := NewProxyHandler(u, &staticKeyReader{key: "stream-key"}, http.DefaultTransport)
+	proxy := httptest.NewServer(handler)
+	defer proxy.Close()
+
+	resp, err := http.Get(proxy.URL + "/stream")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	for i := range 5 {
+		expected := fmt.Sprintf("chunk-%d", i)
+		if !strings.Contains(string(body), expected) {
+			t.Errorf("missing chunk %q in body: %s", expected, body)
+		}
+	}
+}
+
+// --- Key rotation e2e test ---
+
+func TestE2E_KeyRotation(t *testing.T) {
+	var receivedKeys []string
+	var mu sync.Mutex
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		receivedKeys = append(receivedKeys, r.Header.Get("Authorization"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	path := writeKeyFile(t, "key-v1")
+	cr := newConfigKeyReader(path)
+	u, _ := url.Parse(upstream.URL)
+	handler := NewProxyHandler(u, cr, http.DefaultTransport)
+	proxy := httptest.NewServer(handler)
+	defer proxy.Close()
+
+	// Request with key-v1
+	resp, _ := http.Get(proxy.URL + "/test")
+	resp.Body.Close()
+
+	// Rotate key
+	writeKeyFileAt(t, path, "key-v2")
+	future := time.Now().Add(2 * time.Second)
+	os.Chtimes(path, future, future)
+
+	// Request with key-v2
+	resp, _ = http.Get(proxy.URL + "/test")
+	resp.Body.Close()
+
+	// Rotate again
+	writeKeyFileAt(t, path, "key-v3")
+	future2 := time.Now().Add(4 * time.Second)
+	os.Chtimes(path, future2, future2)
+
+	// Request with key-v3
+	resp, _ = http.Get(proxy.URL + "/test")
+	resp.Body.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	expected := []string{"Bearer key-v1", "Bearer key-v2", "Bearer key-v3"}
+	if len(receivedKeys) != 3 {
+		t.Fatalf("expected 3 requests, got %d", len(receivedKeys))
+	}
+	for i, want := range expected {
+		if receivedKeys[i] != want {
+			t.Errorf("request %d: got %q, want %q", i, receivedKeys[i], want)
+		}
+	}
+}
+
+// --- Full e2e test with real listener ---
+
+func TestE2E_FullProxyLifecycle(t *testing.T) {
+	var requestCount atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		if r.Header.Get("Authorization") == "" {
+			t.Error("missing Authorization header")
+		}
+		w.Header().Set("X-Upstream", "true")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer upstream.Close()
+
+	u, _ := url.Parse(upstream.URL)
+	handler := NewProxyHandler(u, &staticKeyReader{key: "e2e-agent-key"}, http.DefaultTransport)
+
+	// Start on a random port
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	proxyAddr := listener.Addr().String()
+
+	srv := &http.Server{Handler: handler}
+	go srv.Serve(listener)
+	defer srv.Close()
+
+	// Multiple requests through the proxy
+	for range 5 {
+		resp, err := http.Get("http://" + proxyAddr + "/api/test")
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("got status %d", resp.StatusCode)
+		}
+		if resp.Header.Get("X-Upstream") != "true" {
+			t.Error("missing upstream response header")
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if string(body) != `{"status":"ok"}` {
+			t.Errorf("got body %q", string(body))
+		}
+	}
+
+	if requestCount.Load() != 5 {
+		t.Errorf("expected 5 upstream requests, got %d", requestCount.Load())
+	}
+}
+
+// --- E2E: concurrent requests during key rotation ---
+
+func TestE2E_ConcurrentRequestsDuringRotation(t *testing.T) {
+	var mu sync.Mutex
+	keys := make(map[string]int)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		keys[r.Header.Get("Authorization")]++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	path := writeKeyFile(t, "initial-key")
+	cr := newConfigKeyReader(path)
+	u, _ := url.Parse(upstream.URL)
+	handler := NewProxyHandler(u, cr, http.DefaultTransport)
+	proxy := httptest.NewServer(handler)
+	defer proxy.Close()
+
+	var wg sync.WaitGroup
+
+	// Fire 20 requests, rotate the key midway.
+	for i := range 20 {
+		if i == 10 {
+			writeKeyFileAt(t, path, "rotated-key")
+			future := time.Now().Add(2 * time.Second)
+			os.Chtimes(path, future, future)
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err := http.Get(proxy.URL + "/test")
+			if err != nil {
+				t.Errorf("request failed: %v", err)
+				return
+			}
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("got status %d", resp.StatusCode)
+			}
+		}()
+	}
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// All requests should have used one of the two keys.
+	total := 0
+	for auth, count := range keys {
+		if auth != "Bearer initial-key" && auth != "Bearer rotated-key" {
+			t.Errorf("unexpected key: %q", auth)
+		}
+		total += count
+	}
+	if total != 20 {
+		t.Errorf("expected 20 total requests, got %d", total)
+	}
+}
+
+// --- E2E: SSE streaming with key injection ---
+
+func TestE2E_SSEWithKeyInjection(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer sse-key" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		flusher := w.(http.Flusher)
+		for i := range 3 {
+			fmt.Fprintf(w, "id: %d\ndata: message-%d\n\n", i, i)
+			flusher.Flush()
+			time.Sleep(10 * time.Millisecond)
+		}
+	}))
+	defer upstream.Close()
+
+	u, _ := url.Parse(upstream.URL)
+	handler := NewProxyHandler(u, &staticKeyReader{key: "sse-key"}, http.DefaultTransport)
+
+	listener, _ := net.Listen("tcp", "127.0.0.1:0")
+	srv := &http.Server{Handler: handler}
+	go srv.Serve(listener)
+	defer srv.Close()
+
+	resp, err := http.Get("http://" + listener.Addr().String() + "/events")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got status %d, want 200", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	for i := range 3 {
+		if !strings.Contains(string(body), fmt.Sprintf("data: message-%d", i)) {
+			t.Errorf("missing event %d in SSE stream", i)
+		}
+	}
+}
+
+// --- E2E: large response body ---
+
+func TestE2E_LargeResponseBody(t *testing.T) {
+	largeBody := strings.Repeat("x", 1024*1024) // 1MB
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(largeBody))
+	}))
+	defer upstream.Close()
+
+	u, _ := url.Parse(upstream.URL)
+	handler := NewProxyHandler(u, &staticKeyReader{key: "tok"}, http.DefaultTransport)
+	proxy := httptest.NewServer(handler)
+	defer proxy.Close()
+
+	resp, err := http.Get(proxy.URL + "/large")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if len(body) != len(largeBody) {
+		t.Errorf("got %d bytes, want %d", len(body), len(largeBody))
+	}
+}
+
+// --- buildTransport tests ---
+
+func TestBuildTransport_NoCA(t *testing.T) {
+	tr, err := buildTransport("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tr.TLSClientConfig.RootCAs != nil {
+		t.Error("expected nil RootCAs when no ca_file")
+	}
+}
+
+func TestBuildTransport_InvalidCAFile(t *testing.T) {
+	_, err := buildTransport("/nonexistent/ca.pem")
+	if err == nil {
+		t.Fatal("expected error for missing CA file")
+	}
+}
+
+func TestBuildTransport_InvalidPEM(t *testing.T) {
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "bad.pem")
+	os.WriteFile(caPath, []byte("not-a-certificate"), 0o600)
+
+	_, err := buildTransport(caPath)
+	if err == nil {
+		t.Fatal("expected error for invalid PEM")
+	}
+}
+
+// --- Helpers ---
+
+// writeKeyFile writes a config YAML with the given key and returns the path.
+func writeKeyFile(t *testing.T, key string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := fmt.Sprintf("server: https://example.com\nkey: %q\n", key)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// writeKeyFileAt overwrites an existing config file with the given key.
+func writeKeyFileAt(t *testing.T, path, key string) {
+	t.Helper()
+	content := fmt.Sprintf("server: https://example.com\nkey: %q\n", key)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/wardgate-proxy/main_test.go
+++ b/cmd/wardgate-proxy/main_test.go
@@ -295,6 +295,107 @@ func TestLoadConfig_InvalidYAML(t *testing.T) {
 	}
 }
 
+// --- resolveConfig tests ---
+
+func TestResolveConfig_ExplicitMissingFile(t *testing.T) {
+	_, err := resolveConfig("/nonexistent/config.yaml", true, "", "", "")
+	if err == nil {
+		t.Fatal("expected error for explicit missing config")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got: %v", err)
+	}
+}
+
+func TestResolveConfig_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte("{{{invalid"), 0o600)
+
+	_, err := resolveConfig(path, true, "", "", "")
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+	if !strings.Contains(err.Error(), "parsing config") {
+		t.Errorf("expected 'parsing config' in error, got: %v", err)
+	}
+}
+
+func TestResolveConfig_MissingServer(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte("key: my-key\n"), 0o600)
+
+	_, err := resolveConfig(path, true, "", "", "")
+	if err == nil {
+		t.Fatal("expected error for missing server")
+	}
+	if !strings.Contains(err.Error(), "server URL not configured") {
+		t.Errorf("expected 'server URL not configured' in error, got: %v", err)
+	}
+}
+
+func TestResolveConfig_MissingKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte("server: https://example.com\n"), 0o600)
+
+	_, err := resolveConfig(path, true, "", "", "")
+	if err == nil {
+		t.Fatal("expected error for missing key")
+	}
+	if !strings.Contains(err.Error(), "agent key not configured") {
+		t.Errorf("expected 'agent key not configured' in error, got: %v", err)
+	}
+}
+
+func TestResolveConfig_ValidConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte("server: https://example.com\nkey: my-key\nlisten: 127.0.0.1:9090\n"), 0o600)
+
+	cfg, err := resolveConfig(path, true, "", "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Server != "https://example.com" {
+		t.Errorf("server: got %q", cfg.Server)
+	}
+	if cfg.Key != "my-key" {
+		t.Errorf("key: got %q", cfg.Key)
+	}
+	if cfg.Listen != "127.0.0.1:9090" {
+		t.Errorf("listen: got %q", cfg.Listen)
+	}
+}
+
+func TestResolveConfig_FlagOverrides(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte("server: https://example.com\nkey: my-key\n"), 0o600)
+
+	cfg, err := resolveConfig(path, true, "0.0.0.0:8080", "https://override.com", "MY_KEY_ENV")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Listen != "0.0.0.0:8080" {
+		t.Errorf("listen: got %q, want 0.0.0.0:8080", cfg.Listen)
+	}
+	if cfg.Server != "https://override.com" {
+		t.Errorf("server: got %q, want https://override.com", cfg.Server)
+	}
+	if cfg.KeyEnv != "MY_KEY_ENV" {
+		t.Errorf("key_env: got %q, want MY_KEY_ENV", cfg.KeyEnv)
+	}
+}
+
+func TestResolveConfig_ImplicitMissingFileUsesDefaults(t *testing.T) {
+	_, err := resolveConfig("/nonexistent/config.yaml", false, "", "https://example.com", "MY_KEY")
+	if err != nil {
+		t.Fatalf("unexpected error for implicit missing config with flag overrides: %v", err)
+	}
+}
+
 // --- Proxy handler unit tests ---
 
 func TestProxyHandler_InjectsBearer(t *testing.T) {

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,7 @@ conclaves:
 
 - [Conclaves](conclaves.md) -- Isolated remote execution environments, policy rules, deployment
 - [wardgate-cli](wardgate-cli.md) -- Restricted HTTP client and conclave exec tool for agents
+- [wardgate-proxy](wardgate-proxy.md) -- Local reverse proxy for agents with their own HTTP clients, or tools
 - [wardgate-cli AI Skill](../skills/wardgate-cli/SKILL.md) -- Skill file to teach AI agents how to use wardgate-cli
 
 ### Operations
@@ -70,6 +71,7 @@ conclaves:
 Wardgate includes a web dashboard (`/ui/`) and CLI for managing approval requests. Configure `admin_key_env` in your server settings to enable. See the [README](../README.md) for an overview.
 
 The dashboard includes:
+
 - **Pending** -- Requests awaiting approval
 - **History** -- Past approval decisions
 - **Logs** -- Recent request activity with filtering

--- a/docs/wardgate-proxy.md
+++ b/docs/wardgate-proxy.md
@@ -1,0 +1,177 @@
+# wardgate-proxy
+
+A local reverse proxy for AI agents that transparently injects the agent key into every outgoing request. It sits between the agent and a Wardgate server, reading an agent key from config and adding it as an `Authorization: Bearer` header.
+
+## Why It Exists
+
+`wardgate-cli` replaces `curl` entirely and locks the agent to a single server. But some agents use their own HTTP clients (Python `requests`, Node `fetch`, etc.) and can't be forced to use a custom binary.
+
+`wardgate-proxy` solves this differently: it runs as a local HTTP proxy on `127.0.0.1`. The agent makes plain HTTP requests to the proxy, and the proxy forwards them to Wardgate with the agent key injected. The agent never sees the key.
+
+| Approach | How it works | Best for |
+|----------|-------------|----------|
+| `wardgate-cli` | Replaces curl; fixed config path compiled in | Sandboxed containers where you control the toolset |
+| `wardgate-proxy` | Local proxy; any HTTP client works | Agents with their own HTTP clients, or multi-tool setups |
+
+## How It Works
+
+```
+Agent (any HTTP client)
+  → http://127.0.0.1:18080/todoist/tasks
+    → wardgate-proxy reads agent key from config
+      → https://wardgate.example.com/todoist/tasks (with Bearer <agent-key>)
+```
+
+1. Agent sends a request to `wardgate-proxy` (no auth required)
+2. Proxy reads the agent key from config (cached by mtime, auto-rotated)
+3. Proxy forwards the request to the Wardgate server with `Authorization: Bearer <agent-key>`
+4. Response is streamed back to the agent (SSE and chunked transfer supported)
+
+## Installation
+
+### Pre-built Binaries
+
+Download from [GitHub Releases](https://github.com/wardgate/wardgate/releases).
+
+### Go Install
+
+```bash
+go install github.com/wardgate/wardgate/cmd/wardgate-proxy@latest
+```
+
+### Build from Source
+
+```bash
+go build -o wardgate-proxy ./cmd/wardgate-proxy
+```
+
+## Configuration
+
+### Config File
+
+Create `wardgate-proxy.yaml` (default path, or specify with `-config`):
+
+```yaml
+server: https://wardgate.example.com
+key: "your-agent-key"
+listen: 127.0.0.1:18080
+```
+
+Or use an environment variable for the key:
+
+```yaml
+server: https://wardgate.example.com
+key_env: WARDGATE_AGENT_KEY
+listen: 127.0.0.1:18080
+```
+
+**Custom CA:** If Wardgate uses HTTPS with an internal CA, add `ca_file`:
+
+```yaml
+server: https://wardgate.internal:443
+key_env: WARDGATE_AGENT_KEY
+ca_file: /etc/wardgate-proxy/ca.pem
+```
+
+### Config Fields
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `server` | Wardgate server URL (required) | -- |
+| `key` | Agent key (takes priority over `key_env`) | -- |
+| `key_env` | Environment variable containing the agent key | -- |
+| `listen` | Local address to listen on | `127.0.0.1:18080` |
+| `ca_file` | Path to custom CA certificate (PEM) | -- |
+
+One of `key` or `key_env` is required.
+
+### CLI Flags
+
+Flags override config file values:
+
+```bash
+wardgate-proxy \
+  -config wardgate-proxy.yaml \
+  -server https://wardgate.example.com \
+  -key-env WARDGATE_AGENT_KEY \
+  -listen 127.0.0.1:9090
+```
+
+| Flag | Description |
+|------|-------------|
+| `-config` | Path to config file (default: `wardgate-proxy.yaml`) |
+| `-server` | Wardgate server URL |
+| `-key-env` | Environment variable containing agent key |
+| `-listen` | Listen address |
+| `-version` | Show version and exit |
+
+## Key Resolution
+
+Priority: `key` > `key_env`. This matches `wardgate-cli` conventions.
+
+- If `key` is set in the config file, it is used directly. The proxy watches the config file's mtime and re-reads the `key` field when it changes, supporting key rotation without restart.
+- If `key_env` is set, the named environment variable is read at startup. The key is fixed for the process lifetime (restart to rotate).
+- If neither is set, the proxy refuses to start.
+
+## Usage
+
+### Start the Proxy
+
+```bash
+# With config file
+wardgate-proxy
+
+# With flags
+wardgate-proxy -server https://wardgate.example.com -key-env WARDGATE_AGENT_KEY
+```
+
+### Agent Requests
+
+The agent makes requests to the proxy as if it were the Wardgate server:
+
+```bash
+# From the agent's perspective -- no auth needed
+curl http://127.0.0.1:18080/todoist/tasks
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"content":"Buy milk"}' \
+  http://127.0.0.1:18080/todoist/tasks
+```
+
+The proxy injects the agent key and forwards to the real Wardgate server. Any `Authorization` header the agent sends is overwritten.
+
+### Key Rotation
+
+When using `key` in the config file, write the new key to the config and the proxy picks it up on the next request (detected by mtime change). No restart required.
+
+If the config file is partially written (YAML parse error or empty key), the proxy falls back to the last known good key and logs a warning.
+
+When using `key_env`, restart the proxy to rotate the key.
+
+## Security Model
+
+| Aspect | Behavior |
+|--------|----------|
+| Agent key storage | In config file or environment variable, never exposed to agent |
+| Key injection | `Authorization: Bearer` header set on every request |
+| Agent auth | Overwritten -- agent cannot send its own key upstream |
+| `X-Forwarded-For` | Stripped to prevent IP leakage |
+| Listen address | `127.0.0.1` by default (localhost only) |
+
+**Compared to `wardgate-cli`:** The proxy does not restrict which paths the agent requests -- it forwards everything to the configured Wardgate server. Access control is enforced by Wardgate's policy engine, not the proxy.
+
+## Docker Example
+
+```yaml
+services:
+  wardgate-proxy:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: wardgate-proxy  # if using multi-stage
+    volumes:
+      - ./wardgate-proxy.yaml:/etc/wardgate-proxy/config.yaml:ro
+    command: ["-config", "/etc/wardgate-proxy/config.yaml"]
+    network_mode: "service:agent"  # share network namespace with agent
+```
+
+By sharing the network namespace, the agent reaches the proxy at `127.0.0.1:18080` without exposing it to other containers.

--- a/skills/wardgate-proxy/SKILL.md
+++ b/skills/wardgate-proxy/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: wardgate-proxy
+description: >
+  Use wardgate-proxy to call APIs through Wardgate. Use when the agent runs behind a local
+  wardgate-proxy and needs to make HTTP requests to external services. The agent uses any
+  HTTP client (curl, requests, fetch) pointing at the proxy address -- no special binary needed.
+compatibility: Requires wardgate-proxy running on a known local address (default 127.0.0.1:18080).
+---
+
+# wardgate-proxy
+
+A local reverse proxy that transparently injects the agent key into every request to a Wardgate server. The agent makes plain HTTP requests to the proxy using any HTTP client -- no special binary, no shell access, no restarts required.
+
+## How it works
+
+```
+Your HTTP request → http://127.0.0.1:18080/todoist/tasks
+  → wardgate-proxy injects agent key
+    → https://wardgate.example.com/todoist/tasks (with Bearer <agent-key>)
+      → response streamed back to you
+```
+
+The proxy handles authentication automatically. You never see or manage the agent key.
+
+## Key constraints
+
+- **Fixed server** -- all requests go to the Wardgate server configured in the proxy. You cannot change the destination.
+- **Auth is automatic** -- do not pass `Authorization` headers. Any you send will be overwritten by the proxy.
+- **Access control is server-side** -- Wardgate's policy engine decides what's allowed. If a request is denied, the response will tell you why.
+
+## Discovery -- always start here
+
+Before making requests, discover what endpoints are available:
+
+```bash
+curl http://127.0.0.1:18080/endpoints
+```
+
+Returns JSON with `name`, `description`, `upstream`, and `docs_url` for each endpoint. Use the endpoint name as the first path segment in all requests.
+
+## Making requests
+
+Use any HTTP client. The proxy address is `http://127.0.0.1:18080` by default.
+
+### curl
+
+```bash
+# GET
+curl http://127.0.0.1:18080/todoist/tasks
+
+# POST with JSON body
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"content":"Buy milk"}' \
+  http://127.0.0.1:18080/todoist/tasks
+
+# PUT
+curl -X PUT -H "Content-Type: application/json" \
+  -d '{"content":"Buy oat milk"}' \
+  http://127.0.0.1:18080/todoist/tasks/123
+
+# DELETE
+curl -X DELETE http://127.0.0.1:18080/todoist/tasks/123
+```
+
+### Python
+
+```python
+import requests
+
+BASE = "http://127.0.0.1:18080"
+
+# GET
+tasks = requests.get(f"{BASE}/todoist/tasks").json()
+
+# POST
+requests.post(f"{BASE}/todoist/tasks", json={"content": "Buy milk"})
+```
+
+### Node.js
+
+```javascript
+const BASE = "http://127.0.0.1:18080";
+
+// GET
+const resp = await fetch(`${BASE}/todoist/tasks`);
+const tasks = await resp.json();
+
+// POST
+await fetch(`${BASE}/todoist/tasks`, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ content: "Buy milk" }),
+});
+```
+
+## Custom headers
+
+All headers you send (except `Authorization` and `X-Forwarded-For`) are forwarded to the Wardgate server and then to the upstream API. Use this for `Content-Type`, `Accept`, or any other headers the upstream expects.
+
+```bash
+curl -H "Accept: application/json" \
+  -H "X-Request-Id: req-123" \
+  http://127.0.0.1:18080/my-endpoint/resource
+```
+
+### Sealed credentials
+
+If the endpoint is configured for sealed credentials, you can send encrypted headers via `X-Wardgate-Sealed-*` prefixed headers. The Wardgate server decrypts them before forwarding to the upstream.
+
+```bash
+# Encrypt a credential with the endpoint's public seal key, then send it:
+curl -H "X-Wardgate-Sealed-Authorization: <base64-encrypted-value>" \
+  http://127.0.0.1:18080/my-endpoint/resource
+```
+
+Allowed sealed headers: `Authorization`, `X-Api-Key`, `X-Auth-Token`, `Proxy-Authorization`. The Wardgate server strips the `X-Wardgate-Sealed-` prefix after decryption and sets the real header.
+
+## Streaming and SSE
+
+The proxy supports Server-Sent Events and chunked transfer encoding. Responses are flushed immediately -- no buffering.
+
+```bash
+curl -N http://127.0.0.1:18080/my-endpoint/events
+```
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Connection refused on `:18080` | Proxy not running | Check that wardgate-proxy is started |
+| 502 Bad Gateway with "key error" | Proxy cannot read agent key | Check proxy config file |
+| 502 Bad Gateway with "proxy error" | Wardgate server unreachable | Check proxy's `server` config |
+| 403 Forbidden | Wardgate policy denied the request | Read the response body; use only allowed methods/paths |
+| 401 Unauthorized | Agent key invalid or expired | Key rotation needed in proxy config |
+
+## Important rules
+
+1. **Always call `/endpoints` first** to discover what's available before guessing paths.
+2. **Never fabricate endpoint paths** -- use only what discovery returns.
+3. **Do not pass Authorization headers** -- auth is handled by the proxy.
+4. **Respect denials** -- if a request is denied by policy, do not attempt workarounds.
+5. **Use the proxy address for all external service requests** -- do not call upstream APIs directly.


### PR DESCRIPTION
## Summary

wardgate-proxy is a local reverse proxy that sits between sandboxed AI agents and a Wardgate server. It solves a specific deployment gap: agents that use their own HTTP clients (Python `requests`, Node `fetch`, Go `net/http`) cannot be forced to use `wardgate-cli` as a curl replacement, especially when they don't have shell access to invoke binaries.

The proxy runs on `127.0.0.1`, accepts plain HTTP requests from the agent, injects the agent key as a `Bearer` token, and forwards everything to Wardgate. The agent never sees credentials, and no code changes are needed on the agent side -- just point the base URL at the proxy.

## Key features

- **Any HTTP client works** -- no special binary needed. The agent makes standard HTTP requests to `http://127.0.0.1:18080/...`
- **Config aligned with wardgate-cli** -- uses `key`/`key_env` fields instead of a separate token file, consistent naming across both tools
- **Zero-downtime key rotation** -- when using `key` in config, the proxy watches the config file's mtime and re-reads on change. Half-written files during rotation are handled gracefully (falls back to cached key, logs a warning)
- **Full header passthrough** -- custom headers, sealed credentials (`X-Wardgate-Sealed-*`), content types all flow through to Wardgate transparently
- **Streaming support** -- SSE and chunked transfer encoding are flushed immediately with no buffering
- **AI skill file** -- `skills/wardgate-proxy/SKILL.md` teaches agents how to use the proxy with examples in curl, Python, and Node.js

## When to use which

| Tool | Best for |
|------|----------|
| `wardgate-cli` | Sandboxed containers where you control the toolset and can replace `curl` |
| `wardgate-proxy` | Agents with their own HTTP clients, multi-tool setups, or environments without shell access |

## Test plan

- [x] 33 unit and e2e tests pass with race detector (`go test -v -race ./cmd/wardgate-proxy/`)
- [x] Live e2e test: echo server -> wardgate server -> wardgate-proxy -> curl (GET, POST, discovery, auth overwrite verified)
- [x] `go build ./...` and `go vet ./...` clean
- [x] DCO sign-off included

🤖 Generated with [Claude Code](https://claude.com/claude-code)